### PR TITLE
[Feat] random_walk 함수 edge penalty 수정 및 degree penalty 추가

### DIFF
--- a/src/service/path_finder.py
+++ b/src/service/path_finder.py
@@ -50,15 +50,10 @@ def random_walk_route(G: nx.Graph, start_node: int, target_distance_km: float = 
         weights = []
         for n in neighbors:
             edge_key = tuple(sorted([current, n]))
-            visit_count = visited_edges.get(edge_key, 0)
+            edge_visited = visited_edges.get(edge_key, 0)
 
-            # 2회 이상 방문 차단, 1회는 페널티
-            if visit_count >= 2:
-                penalty = 0.0
-            elif visit_count == 1:
-                penalty = 1 / 6  # 1 / (1 + 1 * 5)
-            else:
-                penalty = 1.0
+            edge_penalty = 1.0 / (1 + edge_visited * 7)
+            degree_penalty = 1.0 / (1 + max(0, 3 - G.degree(n)))  # degree 1→0.25, 2→0.5, 3→1.0
 
             edge_data = G.get_edge_data(current, n) or {}
             w = edge_data.get(weight, 1.0)
@@ -71,17 +66,7 @@ def random_walk_route(G: nx.Graph, start_node: int, target_distance_km: float = 
                 dist_from_start = ((nx_ - start_x)**2 + (ny_ - start_y)**2) ** 0.5
                 w = w / ((dist_from_start + 1e-6) ** 2)
             
-            weights.append((1.0 / w) * penalty)
-
-        # 전부 차단된 경우 fallback: 페널티 무시하고 최소 방문 엣지로
-        if all(w == 0.0 for w in weights):
-            weights = []
-            for n in neighbors:
-                edge_key = tuple(sorted([current, n]))
-                visit_count = visited_edges.get(edge_key, 0)
-                edge_data = G.get_edge_data(current, n) or {}
-                w = edge_data.get(weight, 1.0)
-                weights.append((1.0 / w) / (1 + visit_count * 10))
+            weights.append((1.0 / w) * edge_penalty * degree_penalty)
 
         total_w = sum(weights)
         probs = [w / total_w for w in weights]


### PR DESCRIPTION
## ☝️Issue Number
- resolve #35 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 방문한 엣지에 가중치 페널티 부여 (visit_count 기반 지수 감쇠)
- 낮은 degree 노드 진입 억제 (degree penalty 추가)
- 기존 2회 방문 차단 방식 → 페널티 방식으로 변경 (dead end 방지)
- fallback 로직 제거 (penalty가 0이 되는 경우 없음)
- 귀환 경로에도 엣지 페널티 반영

## 페널티 공식
- edge_penalty = 1.0 / (1 + visit_count * 7)
- degree_penalty = 1.0 / (1 + max(0, 3 - degree(n)))
  - degree 1: 0.25, degree 2: 0.5, degree 3+: 1.0

## 테스트
- 명동, 은평뉴타운 등 다양한 출발 노드로 검증
- 아파트 단지 내 중복 엣지 패턴 개선 확인