### PR TITLE
[Feature] h3-pg 도입 및 nature_score 컬럼 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgis/postgis:16-3.4
+
+RUN apt-get update \
+    && apt-get install -y postgresql-16-h3 \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:   # 이름은 다를 수 있습니다 (postgres 등)
     platform: linux/amd64
-    image: postgis/postgis:16-3.4
+    build: .
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-seoul_walk}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}

--- a/src/entity/walk_network.py
+++ b/src/entity/walk_network.py
@@ -22,5 +22,6 @@ class WalkEdge(Base):
     road_type: Mapped[str] = mapped_column(String(20), nullable=True) 
     path_type: Mapped[str] = mapped_column(String(20), default="sidewalk")
     safety_score: Mapped[float] = mapped_column(Float, default=0.0)
+    nature_score: Mapped[float] = mapped_column(Float, default=0.0)
     slope_score: Mapped[float] = mapped_column(Float, default=0.0)
     geom = mapped_column(Geometry("LINESTRING", srid=4326), nullable=False)


### PR DESCRIPTION
## ☝️Issue Number
- resolve #46

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- PostGIS 베이스 이미지에 h3-pg를 추가한 커스텀 Dockerfile 작성 및 docker-compose.yml 빌드 방식 변경
- `walk_edges` 테이블 및 ORM에 `nature_score` 컬럼 추가

## 🔧 팀원 필수 작업
1. 이미지 재빌드
   ```bash
   docker-compose down
   docker-compose up -d --build
2. DB 접속
   docker-compose exec db psql -U postgres -d seoul_walk  
3. h3 extension 활성화 (최초 1회)
   CREATE EXTENSION IF NOT EXISTS h3;
   CREATE EXTENSION IF NOT EXISTS h3_postgis CASCADE;
4. nature_score 컬럼 추가
   ALTER TABLE walk_edges ADD COLUMN nature_score FLOAT DEFAULT 0.0;

