### PR TITLE
[Feat] 런닝/다이어트 모드 순환/편도 경로 추천 기능 구현

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,10 +90,29 @@ def get_weather(lat, lng):
             "air_status": "알 수 없음",
             "air_msg": "",
         }
+    
+# ── [배너] get_banner_list 함수 ──────────────────
+def get_banner_list(weather: dict, hour: int | None = None) -> list:
+    if hour is None:
+        hour = datetime.now().hour
 
-env = get_weather(lat, lng)
-print(f"weather: {time.time()-t:.2f}s"); t = time.time()
+    status = weather.get("weather_status", "")
+    msg    = weather.get("weather_msg", "")
+    banners = []
 
+    # 1순위: 이벤트 배너
+    active_event = get_active_event()
+    if active_event:
+        banners.append(_get_event_text(active_event))
+
+    # 2순위: 시즌 배너 (날씨 기반)
+    if _is_hot(msg):
+        if 6 <= hour < 9:
+            banners.append(BANNERS["season"]["hot_morning"])
+        elif _is_humid(status):
+            banners.append(BANNERS["season"]["hot_humid"])
+        else:
+            banners.append(BANNERS["season"]["hot_sunny"])
 
     # 3순위: 고정 배너 (시간대 기반 전체 추가)
     if hour < 17:
@@ -107,6 +126,12 @@ print(f"weather: {time.time()-t:.2f}s"); t = time.time()
         banners.append(BANNERS["fixed"][key])
 
     return banners
+# ─────────────────────────────────────────────────
+
+env = get_weather(lat, lng)
+
+env = get_weather(lat, lng)
+print(f"weather: {time.time()-t:.2f}s"); t = time.time()
 
 banners = get_banner_list(weather=env)
 

--- a/app.py
+++ b/app.py
@@ -576,7 +576,7 @@ if input_mode == "직접 설정" and st.session_state.start:
                         if st.session_state.end
                         else None
                     ),
-                    "purpose": purpose,
+                    "purpose": "산책",
                 }
                 weights = {"safety": safety_w, "nature": nature_w}
                 result = get_route(context, weights, G)

--- a/src/api/running_router.py
+++ b/src/api/running_router.py
@@ -1,0 +1,122 @@
+"""
+런닝/다이어트 모드 API 라우터
+
+엔드포인트
+----------
+POST /api/running/circular  → 순환 코스 추천
+POST /api/running/oneway    → 편도 코스 추천
+
+main.py 등록 방법 (팀원과 합의 후 추가)
+----------------------------------------
+    from src.api import running_router
+    app.include_router(running_router.router)
+"""
+
+from fastapi import APIRouter, HTTPException
+import traceback
+
+from src.schema.running_schema import (
+    CircularRunningRequest,
+    CircularRunningResponse,
+    CourseInfo,
+    OnewayRunningRequest,
+    OnewayRunningResponse,
+)
+from src.service.route.running_route_service import (
+    get_circular_route,
+    get_oneway_route,
+)
+
+router = APIRouter(
+    prefix="/api/running",
+    tags=["running"],
+)
+
+
+# ──────────────────────────────────────────────────────────────
+# 순환 코스
+# ──────────────────────────────────────────────────────────────
+
+@router.post("/circular", response_model=CircularRunningResponse)
+async def circular_running(request: CircularRunningRequest):
+    """
+    출발점 기준 순환(루프) 런닝 코스를 추천합니다.
+
+    - 하천변·공원 위주 경로를 선호합니다.
+    - DB에서 반경 내 순환 코스 목록도 함께 반환합니다.
+
+    **요청 예시**
+    ```json
+    {
+        "lat": 37.5285,
+        "lng": 126.9326,
+        "target_km": 5.0,
+        "radius_m": 5000
+    }
+    ```
+    """
+    try:
+        result = get_circular_route(
+            lat=request.lat,
+            lng=request.lng,
+            target_km=request.target_km,
+            radius_m=request.radius_m,
+        )
+    except Exception as e:
+        traceback.print_exc()  # 터미널에 전체 에러 출력
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return CircularRunningResponse(
+        mode=result.get("mode", "circular_running"),
+        coordinates=result.get("coordinates", []),
+        total_distance_km=result.get("total_distance_km", 0.0),
+        matched_courses=[CourseInfo(**c) for c in result.get("matched_courses", [])],
+        error=result.get("error"),
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# 편도 코스
+# ──────────────────────────────────────────────────────────────
+
+@router.post("/oneway", response_model=OnewayRunningResponse)
+async def oneway_running(request: OnewayRunningRequest):
+    """
+    출발점 → 도착점 편도 런닝 코스를 추천합니다.
+
+    - `use_random=true` : 하천변·공원을 경유하는 우회 경로 (더 긴 거리)
+    - `use_random=false`: 최단 경로 (Dijkstra)
+
+    **요청 예시**
+    ```json
+    {
+        "start_lat": 37.5121,
+        "start_lng": 126.9994,
+        "end_lat": 37.5228,
+        "end_lng": 126.9706,
+        "target_km": 6.0,
+        "use_random": true,
+        "radius_m": 5000
+    }
+    ```
+    """
+    try:
+        result = get_oneway_route(
+            start_lat=request.start_lat,
+            start_lng=request.start_lng,
+            end_lat=request.end_lat,
+            end_lng=request.end_lng,
+            target_km=request.target_km,
+            use_random=request.use_random,
+            radius_m=request.radius_m,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return OnewayRunningResponse(
+        mode=result.get("mode", "oneway_running"),
+        coordinates=result.get("coordinates", []),
+        total_distance_km=result.get("total_distance_km", 0.0),
+        matched_courses=[CourseInfo(**c) for c in result.get("matched_courses", [])],
+        error=result.get("error"),
+    )

--- a/src/data/collectors/running_course_collector.py
+++ b/src/data/collectors/running_course_collector.py
@@ -1,0 +1,355 @@
+"""
+런닝/다이어트 코스 데이터 수집기
+
+서울시 열린데이터광장 데이터를 파싱하여 COURSE + COURSE_TAG 테이블에 삽입합니다.
+
+지원 데이터 소스
+-----------------
+1. 서울시 주요 공원현황 XLSX  → course_type='park',  is_circular=True
+   - 파일: src/data/raw/서울시 주요 공원현황.csv (또는 .xlsx)
+   - 컬럼: 공원명, X좌표(WGS84), Y좌표(WGS84), 면적
+   - 출처: 서울시 열린데이터광장 (2026년 기준 131개 공원)
+
+2. 하천변 코스 정적 데이터 (선형 GeoJSON 미제공으로 직접 정의)
+   - 서울시 하천 현황 CSV는 통계 데이터(좌표 없음)이므로
+     실제 하천 구간 좌표는 직접 정의합니다.
+   - 포함 하천: 한강(반포·여의도), 청계천, 안양천, 중랑천
+
+실행 방법
+---------
+    python -m src.data.collectors.running_course_collector
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import pandas as pd
+from sqlalchemy.orm import Session
+
+from src.database.postgresql import engine
+from src.entity.course import Course, CourseTag
+
+
+# ──────────────────────────────────────────────────────────────
+# 하천변 코스 정적 데이터
+# (서울시 열린데이터광장에 선형 GeoJSON이 없는 경우 직접 정의)
+# ──────────────────────────────────────────────────────────────
+
+RIVER_COURSES: list[dict] = [
+    {
+        "name": "한강 반포 구간",
+        "course_type": "river",
+        "is_circular": False,
+        "distance_m": 6_400,
+        "difficulty": "easy",
+        "description": "반포한강공원 ~ 이촌한강공원 편도 구간. 평탄하고 신호등 없음.",
+        "source": "서울시 열린데이터광장",
+        "start_lat": 37.5121, "start_lng": 126.9994,
+        "end_lat":   37.5228, "end_lng": 126.9706,
+        "tags": ["런닝", "다이어트", "하천변", "야간가능"],
+    },
+    {
+        "name": "한강 여의도 순환 코스",
+        "course_type": "river",
+        "is_circular": True,
+        "distance_m": 7_000,
+        "difficulty": "easy",
+        "description": "여의도한강공원 순환 루프. 자전거도로 겸용 트랙 포함.",
+        "source": "서울시 열린데이터광장",
+        "start_lat": 37.5285, "start_lng": 126.9326,
+        "end_lat":   37.5285, "end_lng": 126.9326,
+        "tags": ["런닝", "다이어트", "하천변", "자전거도로", "야간가능"],
+    },
+    {
+        "name": "청계천 전 구간",
+        "course_type": "river",
+        "is_circular": False,
+        "distance_m": 10_920,
+        "difficulty": "easy",
+        "description": "청계광장 ~ 고산자교 편도. 도심 속 평탄 하천변 코스.",
+        "source": "서울시 열린데이터광장",
+        "start_lat": 37.5700, "start_lng": 126.9784,
+        "end_lat":   37.5637, "end_lng": 127.0636,
+        "tags": ["런닝", "다이어트", "하천변"],
+    },
+    {
+        "name": "안양천 서울 구간",
+        "course_type": "river",
+        "is_circular": False,
+        "distance_m": 12_000,
+        "difficulty": "easy",
+        "description": "안양천 서울 구간 편도. 한강 합류 지점까지 평탄 직선 코스.",
+        "source": "서울시 열린데이터광장",
+        "start_lat": 37.5270, "start_lng": 126.8560,
+        "end_lat":   37.5390, "end_lng": 126.8780,
+        "tags": ["런닝", "다이어트", "하천변"],
+    },
+    {
+        "name": "중랑천 전 구간",
+        "course_type": "river",
+        "is_circular": False,
+        "distance_m": 15_000,
+        "difficulty": "medium",
+        "description": "중랑천 서울 구간 편도. 자전거도로 겸용 트랙 포함.",
+        "source": "서울시 열린데이터광장",
+        "start_lat": 37.6490, "start_lng": 127.0760,
+        "end_lat":   37.5390, "end_lng": 127.0780,
+        "tags": ["런닝", "다이어트", "하천변", "자전거도로"],
+    },
+]
+
+# ──────────────────────────────────────────────────────────────
+# 런닝 적합 공원 목록
+# 서울시 주요 공원현황 XLSX 실제 데이터 기반으로 확인된 공원명
+# (XLSX 공원명 컬럼과 정확히 일치해야 필터링됨)
+# ──────────────────────────────────────────────────────────────
+
+# 공원명 → 추가 태그 매핑
+# XLSX에 실제 존재하는 공원명만 포함 (2026년 기준 확인)
+RUNNING_PARK_CONFIG: dict[str, dict] = {
+    # 대형 순환 트랙 보유 공원 (런닝 최적)
+    "올림픽공원":       {"tags": ["런닝", "다이어트", "공원", "자전거도로", "야간가능"], "difficulty_override": "easy"},
+    "보라매공원":       {"tags": ["런닝", "다이어트", "공원", "야간가능"],              "difficulty_override": "easy"},
+    "서울숲":           {"tags": ["런닝", "다이어트", "공원", "하천변", "야간가능"],    "difficulty_override": "easy"},
+    "월드컵공원":       {"tags": ["런닝", "다이어트", "공원", "야간가능"],              "difficulty_override": "medium"},
+    "북서울꿈의숲":     {"tags": ["런닝", "다이어트", "공원"],                          "difficulty_override": None},
+    # 중형 공원
+    "남산공원":         {"tags": ["런닝", "다이어트", "공원"],                          "difficulty_override": "medium"},
+    "용산가족공원":     {"tags": ["런닝", "다이어트", "공원", "야간가능"],              "difficulty_override": "easy"},
+    "어린이대공원":     {"tags": ["런닝", "다이어트", "공원"],                          "difficulty_override": "easy"},
+    "천호근린공원":     {"tags": ["런닝", "다이어트", "공원"],                          "difficulty_override": "easy"},
+    "여의도근린공원":   {"tags": ["런닝", "다이어트", "공원", "자전거도로", "야간가능"], "difficulty_override": "easy"},
+    "송파나루근린공원(석촌호수)": {"tags": ["런닝", "다이어트", "공원", "야간가능"],   "difficulty_override": "easy"},
+    "선유도근린공원":   {"tags": ["런닝", "다이어트", "공원", "하천변"],               "difficulty_override": "easy"},
+    "노량진공원":       {"tags": ["런닝", "다이어트", "공원"],                          "difficulty_override": "easy"},
+    "손기정체육공원":   {"tags": ["런닝", "다이어트", "공원"],                          "difficulty_override": "easy"},
+    "서서울호수공원":   {"tags": ["런닝", "다이어트", "공원"],                          "difficulty_override": "easy"},
+}
+
+# 필터링용 공원명 목록 (부분 일치 허용)
+RUNNING_PARK_NAMES: list[str] = list(RUNNING_PARK_CONFIG.keys())
+
+
+# ──────────────────────────────────────────────────────────────
+# 헬퍼 함수
+# ──────────────────────────────────────────────────────────────
+
+def _haversine_m(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """두 좌표 간 거리(미터) 계산 — Haversine 공식"""
+    R = 6_371_000
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlam = math.radians(lng2 - lng1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _point_wkt(lat: float, lng: float) -> str:
+    return f"SRID=4326;POINT({lng} {lat})"
+
+
+def _line_wkt(start_lat: float, start_lng: float, end_lat: float, end_lng: float) -> str:
+    """단순 직선 LINESTRING (실제 경로 데이터가 없을 때 대체용)"""
+    return f"SRID=4326;LINESTRING({start_lng} {start_lat}, {end_lng} {end_lat})"
+
+
+def _classify_difficulty(distance_m: Optional[float]) -> str:
+    if distance_m is None:
+        return "easy"
+    if distance_m < 5_000:
+        return "easy"
+    if distance_m < 10_000:
+        return "medium"
+    return "hard"
+
+
+# ──────────────────────────────────────────────────────────────
+# 삽입 함수
+# ──────────────────────────────────────────────────────────────
+
+def _insert_course(session: Session, course_data: dict, tags: list[str]) -> None:
+    """Course + CourseTag 레코드를 세션에 추가 (commit은 호출부에서)"""
+    course = Course(
+        name=course_data["name"],
+        course_type=course_data["course_type"],
+        is_circular=course_data["is_circular"],
+        distance_m=course_data.get("distance_m"),
+        difficulty=course_data.get("difficulty"),
+        description=course_data.get("description"),
+        source=course_data.get("source"),
+        geom=course_data.get("geom"),
+        start_geom=course_data.get("start_geom"),
+        end_geom=course_data.get("end_geom"),
+    )
+    session.add(course)
+    session.flush()  # course.id 확보
+
+    for tag in tags:
+        session.add(CourseTag(course_id=course.id, tag=tag))
+
+
+def load_river_courses(session: Session) -> int:
+    """하천변 코스 정적 데이터 삽입"""
+    count = 0
+    for item in RIVER_COURSES:
+        s_lat, s_lng = item["start_lat"], item["start_lng"]
+        e_lat, e_lng = item["end_lat"],   item["end_lng"]
+
+        course_data = {
+            "name":        item["name"],
+            "course_type": item["course_type"],
+            "is_circular": item["is_circular"],
+            "distance_m":  item.get("distance_m"),
+            "difficulty":  item.get("difficulty", _classify_difficulty(item.get("distance_m"))),
+            "description": item.get("description"),
+            "source":      item.get("source"),
+            "geom":        _line_wkt(s_lat, s_lng, e_lat, e_lng),
+            "start_geom":  _point_wkt(s_lat, s_lng),
+            "end_geom":    _point_wkt(e_lat, e_lng),
+        }
+        _insert_course(session, course_data, item["tags"])
+        count += 1
+
+    return count
+
+
+def load_park_courses(session: Session, xlsx_path: str) -> int:
+    """
+    서울시 주요 공원현황 XLSX에서 런닝 적합 공원을 파싱하여 삽입.
+
+    XLSX 컬럼 (실제 데이터 기준):
+        연번, 관리부서, 전화번호, 공원명, 공원개요, 면적,
+        개원일, 주요시설, 주요식물, 안내도, 오시는길,
+        이용시참고사항, 이미지, 지역, 공원주소,
+        X좌표(GRS80TM), Y좌표(GRS80TM),
+        X좌표(WGS84), Y좌표(WGS84), 바로가기
+
+    Args:
+        session  : SQLAlchemy 세션
+        xlsx_path: XLSX 또는 CSV 파일 경로
+    """
+    # xlsx / csv 모두 지원
+    try:
+        if xlsx_path.endswith(".xlsx"):
+            df = pd.read_excel(xlsx_path, header=1)   # 2번째 행이 실제 컬럼명
+        else:
+            df = pd.read_csv(xlsx_path, encoding="cp949")
+    except FileNotFoundError:
+        print(f"  ⚠️  파일 없음: {xlsx_path} — 공원 코스 삽입 건너뜀")
+        return 0
+
+    # 컬럼명 공백 제거
+    df.columns = [str(c).strip() for c in df.columns]
+
+    # 런닝 적합 공원 필터링 (부분 일치)
+    def _is_running_park(name: str) -> bool:
+        name = str(name).strip()
+        return any(target in name for target in RUNNING_PARK_NAMES)
+
+    mask = df["공원명"].apply(_is_running_park)
+    df_running = df[mask].copy()
+
+    count = 0
+    for _, row in df_running.iterrows():
+        # WGS84 좌표 사용 (X=경도, Y=위도)
+        lng = row.get("X좌표(WGS84)")
+        lat = row.get("Y좌표(WGS84)")
+
+        if pd.isna(lng) or pd.isna(lat):
+            continue
+
+        try:
+            lat, lng = float(lat), float(lng)
+        except (ValueError, TypeError):
+            continue
+
+        # 좌표 유효성 검사 (서울 범위)
+        if not (37.4 <= lat <= 37.7 and 126.7 <= lng <= 127.2):
+            continue
+
+        park_name = str(row["공원명"]).strip()
+
+        # 공원 면적 파싱 (예: "1,513,491.2㎡" → 1513491.2)
+        area_raw = str(row.get("면적", "")).strip()
+        area_m2: Optional[float] = None
+        for token in area_raw.replace(",", "").split():
+            try:
+                val = float(token.replace("㎡", "").replace("m²", ""))
+                if val > 0:
+                    area_m2 = val
+                    break
+            except ValueError:
+                continue
+
+        # 둘레 추정: 정사각형 근사 (둘레 ≈ 4√면적)
+        estimated_distance_m: Optional[float] = None
+        if area_m2:
+            estimated_distance_m = round(4 * math.sqrt(area_m2), 0)
+
+        # 공원별 설정 조회 (정확 일치 우선, 없으면 부분 일치)
+        config = RUNNING_PARK_CONFIG.get(park_name)
+        if config is None:
+            for key, val in RUNNING_PARK_CONFIG.items():
+                if key in park_name:
+                    config = val
+                    break
+        if config is None:
+            config = {"tags": ["런닝", "다이어트", "공원"], "difficulty_override": None}
+
+        difficulty = config["difficulty_override"] or _classify_difficulty(estimated_distance_m)
+
+        course_data = {
+            "name":        f"{park_name} 순환 코스",
+            "course_type": "park",
+            "is_circular": True,
+            "distance_m":  estimated_distance_m,
+            "difficulty":  difficulty,
+            "description": f"{park_name} 내부 순환 런닝 코스.",
+            "source":      "서울시 열린데이터광장 — 서울시 주요 공원현황",
+            "geom":        None,
+            "start_geom":  _point_wkt(lat, lng),
+            "end_geom":    _point_wkt(lat, lng),  # 순환이므로 동일
+        }
+        _insert_course(session, course_data, config["tags"])
+        count += 1
+
+    return count
+
+
+# ──────────────────────────────────────────────────────────────
+# 메인 진입점
+# ──────────────────────────────────────────────────────────────
+
+def collect_running_courses(
+    park_file: str = "src/data/raw/서울시 주요 공원현황.xlsx",
+) -> None:
+    """
+    런닝 코스 전체 수집 및 DB 삽입.
+
+    Args:
+        park_file: 서울시 주요 공원현황 XLSX 또는 CSV 경로
+                   기본값: src/data/raw/서울시 주요 공원현황.xlsx
+    """
+    print("🏃 런닝 코스 데이터 수집 시작...")
+
+    with Session(engine) as session:
+        # 1. 하천변 코스 (정적 데이터)
+        #    서울시 하천 현황 CSV는 통계 데이터(좌표 없음)이므로
+        #    실제 하천 구간 좌표를 직접 정의한 RIVER_COURSES 사용
+        river_count = load_river_courses(session)
+        print(f"  ✅ 하천변 코스 {river_count}건 삽입")
+
+        # 2. 공원 코스 (XLSX 파싱)
+        park_count = load_park_courses(session, park_file)
+        print(f"  ✅ 공원 코스 {park_count}건 삽입")
+
+        session.commit()
+
+    total = river_count + park_count
+    print(f"🎉 완료! 총 {total}건의 런닝 코스가 DB에 저장되었습니다.")
+
+
+if __name__ == "__main__":
+    collect_running_courses()

--- a/src/data/collectors/running_course_migration.py
+++ b/src/data/collectors/running_course_migration.py
@@ -1,0 +1,46 @@
+"""
+런닝 코스 테이블 마이그레이션 스크립트
+
+기존 init_db() 를 건드리지 않고 COURSE / COURSE_TAG 테이블만 독립적으로 생성합니다.
+팀원과 합의 후 init_db() 에 통합하거나, 이 스크립트를 단독 실행해도 됩니다.
+
+실행 방법
+---------
+    python -m src.data.collectors.running_course_migration
+"""
+
+from sqlalchemy import text
+
+from src.database.postgresql import engine
+from src.entity.base import Base
+
+# Course, CourseTag 를 Base.metadata 에 등록하기 위해 반드시 임포트
+from src.entity.course import Course, CourseTag  # noqa: F401
+
+
+def migrate_running_tables() -> None:
+    """COURSE + COURSE_TAG 테이블 생성 (이미 존재하면 건너뜀)"""
+    print("🔧 런닝 코스 테이블 마이그레이션 시작...")
+
+    with engine.begin() as conn:
+        # PostGIS 확장 (이미 설치돼 있으면 무시)
+        conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis;"))
+
+    # checkfirst=True → 테이블이 이미 있으면 건너뜀
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[Course.__table__, CourseTag.__table__],
+        checkfirst=True,
+    )
+
+    print("  ✅ courses 테이블 생성 완료")
+    print("  ✅ course_tags 테이블 생성 완료")
+    print("🎉 마이그레이션 완료!")
+
+
+if __name__ == "__main__":
+    migrate_running_tables()
+
+    # 테이블 생성 후 바로 데이터 삽입하려면 아래 주석 해제
+    # from src.data.collectors.running_course_collector import collect_running_courses
+    # collect_running_courses()

--- a/src/entity/course.py
+++ b/src/entity/course.py
@@ -1,0 +1,117 @@
+"""
+런닝/다이어트 모드 전용 코스 엔티티
+
+COURSE      : 하천변·공원 기반 코스 메타데이터
+COURSE_TAG  : 코스에 붙는 태그 (런닝, 다이어트, 하천변, 공원 등)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from geoalchemy2 import Geometry
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.entity.base import Base
+
+
+class Course(Base):
+    """
+    런닝/다이어트에 적합한 코스 정보.
+
+    Columns
+    -------
+    id              : PK
+    name            : 코스 이름 (예: '한강 반포 구간')
+    course_type     : 'river' | 'park' | 'bike_track'
+    is_circular     : True → 순환 코스, False → 편도 코스
+    distance_m      : 총 거리 (미터)
+    difficulty      : 'easy' | 'medium' | 'hard'
+    description     : 코스 설명
+    source          : 원본 데이터 출처
+    geom            : LINESTRING (경로 전체 선형 지오메트리)
+    start_geom      : POINT (출발점)
+    end_geom        : POINT (도착점, 순환이면 start_geom 과 동일)
+    created_at      : 생성 시각
+    """
+
+    __tablename__ = "courses"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    course_type: Mapped[str] = mapped_column(
+        String(50), nullable=False, comment="river | park | bike_track"
+    )
+    is_circular: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, comment="True=순환, False=편도"
+    )
+    distance_m: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    difficulty: Mapped[Optional[str]] = mapped_column(
+        String(20), nullable=True, comment="easy | medium | hard"
+    )
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    source: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+
+    # PostGIS 지오메트리
+    geom = mapped_column(
+        Geometry("LINESTRING", srid=4326),
+        nullable=True,
+        comment="코스 전체 경로 선형",
+    )
+    start_geom = mapped_column(
+        Geometry("POINT", srid=4326),
+        nullable=True,
+        comment="출발점",
+    )
+    end_geom = mapped_column(
+        Geometry("POINT", srid=4326),
+        nullable=True,
+        comment="도착점 (순환이면 출발점과 동일)",
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+    # 관계
+    tags: Mapped[list[CourseTag]] = relationship(
+        "CourseTag", back_populates="course", cascade="all, delete-orphan"
+    )
+
+    def __repr__(self) -> str:
+        return f"<Course id={self.id} name={self.name!r} type={self.course_type}>"
+
+
+class CourseTag(Base):
+    """
+    코스에 붙는 태그.
+
+    예시 태그: '런닝', '다이어트', '하천변', '공원', '자전거도로', '야간가능'
+    """
+
+    __tablename__ = "course_tags"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    course_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("courses.id", ondelete="CASCADE"), nullable=False
+    )
+    tag: Mapped[str] = mapped_column(String(50), nullable=False)
+
+    # 관계
+    course: Mapped[Course] = relationship("Course", back_populates="tags")
+
+    def __repr__(self) -> str:
+        return f"<CourseTag course_id={self.course_id} tag={self.tag!r}>"

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from src.entity.base import init_db
 from src.api import weather_router, user_router, prewalk_router, auth_router, login_router
+from src.api import running_router
 
 import uvicorn
 
@@ -36,6 +37,7 @@ app.include_router(user_router.router)
 app.include_router(prewalk_router.router)
 app.include_router(auth_router.router)
 app.include_router(login_router.router)
+app.include_router(running_router.router)
 
 @app.get("/")
 def read_root():

--- a/src/repository/course_repository.py
+++ b/src/repository/course_repository.py
@@ -1,0 +1,201 @@
+"""
+런닝/다이어트 코스 레포지토리
+
+PostGIS ST_DWithin 을 활용해 출발점 반경 내 코스를 조회합니다.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from src.database.postgresql import get_postgresql_db
+from src.entity.course import Course, CourseTag
+
+
+# ──────────────────────────────────────────────────────────────
+# 조회 함수
+# ──────────────────────────────────────────────────────────────
+
+def get_courses_near(
+    lat: float,
+    lng: float,
+    radius_m: float = 5_000,
+    is_circular: Optional[bool] = None,
+    course_types: Optional[list[str]] = None,
+    tags: Optional[list[str]] = None,
+    limit: int = 10,
+) -> list[dict]:
+    """
+    출발점 반경 내 코스를 조회합니다.
+
+    Args:
+        lat, lng    : 출발점 위경도
+        radius_m    : 검색 반경 (미터, 기본 5km)
+        is_circular : True=순환, False=편도, None=전체
+        course_types: ['river', 'park', 'bike_track'] 중 복수 선택 가능
+        tags        : 포함해야 할 태그 목록 (AND 조건)
+        limit       : 최대 반환 건수
+
+    Returns:
+        코스 정보 딕셔너리 리스트
+        [
+            {
+                "id": int,
+                "name": str,
+                "course_type": str,
+                "is_circular": bool,
+                "distance_m": float | None,
+                "difficulty": str | None,
+                "description": str | None,
+                "tags": [str, ...],
+                "start_lat": float,
+                "start_lng": float,
+                "end_lat": float | None,
+                "end_lng": float | None,
+                "distance_from_origin_m": float,   # 출발점까지 거리
+            },
+            ...
+        ]
+    """
+    with get_postgresql_db() as db:
+        # ── 동적 WHERE 절 구성 ──────────────────────────────
+        conditions = [
+            "ST_DWithin(c.start_geom::geography, ST_SetSRID(ST_MakePoint(:lng, :lat), 4326)::geography, :radius)"
+        ]
+        params: dict = {"lat": lat, "lng": lng, "radius": radius_m, "limit": limit}
+
+        if is_circular is not None:
+            conditions.append("c.is_circular = :is_circular")
+            params["is_circular"] = is_circular
+
+        if course_types:
+            placeholders = ", ".join(f":ct{i}" for i in range(len(course_types)))
+            conditions.append(f"c.course_type IN ({placeholders})")
+            for i, ct in enumerate(course_types):
+                params[f"ct{i}"] = ct
+
+        where_clause = " AND ".join(conditions)
+
+        # ── 태그 필터 (서브쿼리) ────────────────────────────
+        tag_subquery = ""
+        if tags:
+            tag_placeholders = ", ".join(f":tag{i}" for i in range(len(tags)))
+            tag_subquery = f"""
+                AND c.id IN (
+                    SELECT course_id FROM course_tags
+                    WHERE tag IN ({tag_placeholders})
+                    GROUP BY course_id
+                    HAVING COUNT(DISTINCT tag) = :tag_count
+                )
+            """
+            for i, tag in enumerate(tags):
+                params[f"tag{i}"] = tag
+            params["tag_count"] = len(tags)
+
+        sql = text(f"""
+            SELECT
+                c.id,
+                c.name,
+                c.course_type,
+                c.is_circular,
+                c.distance_m,
+                c.difficulty,
+                c.description,
+                ST_Y(c.start_geom::geometry)  AS start_lat,
+                ST_X(c.start_geom::geometry)  AS start_lng,
+                ST_Y(c.end_geom::geometry)    AS end_lat,
+                ST_X(c.end_geom::geometry)    AS end_lng,
+                ST_Distance(
+                    c.start_geom::geography,
+                    ST_SetSRID(ST_MakePoint(:lng, :lat), 4326)::geography
+                ) AS distance_from_origin_m
+            FROM courses c
+            WHERE {where_clause}
+            {tag_subquery}
+            ORDER BY distance_from_origin_m ASC
+            LIMIT :limit
+        """)
+
+        rows = db.execute(sql, params).fetchall()
+
+        if not rows:
+            return []
+
+        # ── 태그 일괄 조회 ──────────────────────────────────
+        course_ids = [row.id for row in rows]
+        id_placeholders = ", ".join(f":cid{i}" for i in range(len(course_ids)))
+        tag_rows = db.execute(
+            text(f"SELECT course_id, tag FROM course_tags WHERE course_id IN ({id_placeholders})"),
+            {f"cid{i}": cid for i, cid in enumerate(course_ids)},
+        ).fetchall()
+
+        tags_map: dict[int, list[str]] = {}
+        for tr in tag_rows:
+            tags_map.setdefault(tr.course_id, []).append(tr.tag)
+
+        return [
+            {
+                "id":                     row.id,
+                "name":                   row.name,
+                "course_type":            row.course_type,
+                "is_circular":            row.is_circular,
+                "distance_m":             row.distance_m,
+                "difficulty":             row.difficulty,
+                "description":            row.description,
+                "tags":                   tags_map.get(row.id, []),
+                "start_lat":              row.start_lat,
+                "start_lng":              row.start_lng,
+                "end_lat":                row.end_lat,
+                "end_lng":                row.end_lng,
+                "distance_from_origin_m": round(row.distance_from_origin_m, 1),
+            }
+            for row in rows
+        ]
+
+
+def get_course_by_id(course_id: int) -> Optional[dict]:
+    """단일 코스 상세 조회"""
+    with get_postgresql_db() as db:
+        row = db.execute(
+            text("""
+                SELECT
+                    c.id, c.name, c.course_type, c.is_circular,
+                    c.distance_m, c.difficulty, c.description, c.source,
+                    ST_Y(c.start_geom::geometry) AS start_lat,
+                    ST_X(c.start_geom::geometry) AS start_lng,
+                    ST_Y(c.end_geom::geometry)   AS end_lat,
+                    ST_X(c.end_geom::geometry)   AS end_lng,
+                    ST_AsGeoJSON(c.geom)          AS geojson
+                FROM courses c
+                WHERE c.id = :course_id
+            """),
+            {"course_id": course_id},
+        ).fetchone()
+
+        if not row:
+            return None
+
+        tag_rows = db.execute(
+            text("SELECT tag FROM course_tags WHERE course_id = :cid"),
+            {"cid": course_id},
+        ).fetchall()
+
+        return {
+            "id":          row.id,
+            "name":        row.name,
+            "course_type": row.course_type,
+            "is_circular": row.is_circular,
+            "distance_m":  row.distance_m,
+            "difficulty":  row.difficulty,
+            "description": row.description,
+            "source":      row.source,
+            "tags":        [tr.tag for tr in tag_rows],
+            "start_lat":   row.start_lat,
+            "start_lng":   row.start_lng,
+            "end_lat":     row.end_lat,
+            "end_lng":     row.end_lng,
+            "geojson":     row.geojson,
+        }

--- a/src/repository/user_repository.py
+++ b/src/repository/user_repository.py
@@ -20,4 +20,6 @@ class UserRepository:
         """
         with get_postgresql_db() as db:
             user = db.query(User).filter_by(uuid=uuid).first()
+            if user is None:
+                return None
             return user.id

--- a/src/schema/running_schema.py
+++ b/src/schema/running_schema.py
@@ -1,0 +1,95 @@
+"""
+런닝/다이어트 모드 요청·응답 스키마
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ──────────────────────────────────────────────────────────────
+# 공통
+# ──────────────────────────────────────────────────────────────
+
+class CourseInfo(BaseModel):
+    """DB에서 조회된 추천 코스 요약 정보"""
+    id: int
+    name: str
+    course_type: str                        # river | park | bike_track
+    is_circular: bool
+    distance_m: Optional[float] = None
+    difficulty: Optional[str] = None
+    description: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    start_lat: float
+    start_lng: float
+    end_lat: Optional[float] = None
+    end_lng: Optional[float] = None
+    distance_from_origin_m: float           # 출발점까지 거리
+
+
+# ──────────────────────────────────────────────────────────────
+# 순환 코스 (Circular)
+# ──────────────────────────────────────────────────────────────
+
+class CircularRunningRequest(BaseModel):
+    """
+    순환 런닝 코스 요청
+
+    출발점 좌표와 목표 거리를 받아 루프 코스를 반환합니다.
+    """
+    lat: float = Field(..., description="출발점 위도")
+    lng: float = Field(..., description="출발점 경도")
+    target_km: float = Field(5.0, ge=1.0, le=30.0, description="목표 거리 (km)")
+    radius_m: float = Field(5_000, ge=500, le=20_000, description="코스 검색 반경 (미터)")
+
+
+class CircularRunningResponse(BaseModel):
+    """순환 런닝 코스 응답"""
+    mode: str                                       # "circular_running"
+    coordinates: List[List[float]]                  # [[lat, lng], ...]
+    total_distance_km: float
+    matched_courses: List[CourseInfo] = Field(
+        default_factory=list,
+        description="반경 내 DB 추천 코스 목록",
+    )
+    error: Optional[str] = None
+
+
+# ──────────────────────────────────────────────────────────────
+# 편도 코스 (Oneway)
+# ──────────────────────────────────────────────────────────────
+
+class OnewayRunningRequest(BaseModel):
+    """
+    편도 런닝 코스 요청
+
+    출발점 → 도착점 단방향 코스를 반환합니다.
+    """
+    start_lat: float = Field(..., description="출발점 위도")
+    start_lng: float = Field(..., description="출발점 경도")
+    end_lat: float   = Field(..., description="도착점 위도")
+    end_lng: float   = Field(..., description="도착점 경도")
+    target_km: Optional[float] = Field(
+        None, ge=1.0, le=30.0,
+        description="목표 거리 (km). use_random=True 일 때만 사용됩니다.",
+    )
+    use_random: bool = Field(
+        True,
+        description="True=우회 경로(더 긴 거리), False=최단 경로",
+    )
+    radius_m: float = Field(5_000, ge=500, le=20_000, description="코스 검색 반경 (미터)")
+
+
+class OnewayRunningResponse(BaseModel):
+    """편도 런닝 코스 응답"""
+    mode: str                                       # "oneway_running_random" | "oneway_running_shortest"
+    coordinates: List[List[float]]                  # [[lat, lng], ...]
+    total_distance_km: float
+    matched_courses: List[CourseInfo] = Field(
+        default_factory=list,
+        description="반경 내 DB 추천 코스 목록",
+    )
+    error: Optional[str] = None

--- a/src/service/route/running_route_service.py
+++ b/src/service/route/running_route_service.py
@@ -1,0 +1,288 @@
+"""
+런닝/다이어트 모드 경로 추천 서비스
+
+하천변·공원 위주 코스를 순환(circular) / 편도(oneway) 로 나눠 반환합니다.
+
+주요 함수
+---------
+get_circular_route(lat, lng, target_km, ...)  → 출발점 기준 루프 코스
+get_oneway_route(lat, lng, end_lat, end_lng, ...) → 출발점 → 도착점 단방향 코스
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+import networkx as nx
+
+from src.repository.course_repository import get_courses_near
+from src.repository.graph_repository import load_graph_near
+from src.service.route.path_circular_random import random_walk_route
+from src.service.route.path_oneway_dijkstra import dijkstra_route
+from src.service.route.path_oneway_random import oneway_random_route
+from src.service.route.path_utils import (
+    extract_coordinates,
+    find_nearest_node,
+    prune_dead_ends,
+)
+
+# 런닝 모드에서 선호하는 코스 유형
+RUNNING_COURSE_TYPES = ["river", "park", "bike_track"]
+
+# 런닝 모드 기본 태그 필터
+RUNNING_TAGS = ["런닝"]
+
+
+# ──────────────────────────────────────────────────────────────
+# 내부 헬퍼
+# ──────────────────────────────────────────────────────────────
+
+def _apply_running_weights(G: nx.Graph) -> nx.Graph:
+    """
+    런닝 모드 전용 엣지 가중치 적용.
+
+    하천변·공원 path_type 엣지를 선호하도록 custom_score 를 낮춥니다.
+    - path_type 이 'river' 또는 'park' 이면 가중치 보너스 ×2
+    - safety_score, nature_score 를 균등하게 반영
+    """
+    PREFERRED_PATH_TYPES = {"river", "park", "bike_track", "trail"}
+
+    for u, v, data in G.edges(data=True):
+        length     = data.get("length", 1.0) or 1.0
+        safety     = data.get("safety_score", 1.0) or 1.0
+        nature     = data.get("nature_score", 1.0) or 1.0
+        path_type  = data.get("path_type", "") or ""
+
+        # 하천변·공원 경로 보너스
+        type_bonus = 2.0 if path_type.lower() in PREFERRED_PATH_TYPES else 1.0
+
+        # custom_score 낮을수록 알고리즘이 선호
+        custom_score = length / ((safety * nature * type_bonus) + 1e-6)
+        G[u][v]["custom_score"] = custom_score
+
+    return G
+
+
+def _build_result(
+    G: nx.Graph,
+    nodes: list,
+    mode: str,
+    matched_courses: list[dict],
+) -> dict:
+    """공통 응답 딕셔너리 생성"""
+    pruned = prune_dead_ends(nodes, G, max_branch_length=300)
+    coords = extract_coordinates(G, pruned)
+    total_m = sum(
+        (G.get_edge_data(pruned[i], pruned[i + 1]) or {}).get("length", 0)
+        for i in range(len(pruned) - 1)
+    )
+    return {
+        "mode":               mode,
+        "coordinates":        coords,
+        "total_distance_km":  round(total_m / 1000, 2),
+        "matched_courses":    matched_courses,  # DB에서 찾은 추천 코스 목록
+    }
+
+
+# ──────────────────────────────────────────────────────────────
+# 공개 API
+# ──────────────────────────────────────────────────────────────
+
+def get_circular_route(
+    lat: float,
+    lng: float,
+    target_km: float = 5.0,
+    radius_m: float = 5_000,
+    G: Optional[nx.Graph] = None,
+) -> dict:
+    """
+    출발점 기준 순환(루프) 런닝 코스를 반환합니다.
+
+    1단계: DB에서 출발점 반경 내 순환 코스(하천변·공원) 조회
+    2단계: 그래프 기반 random_walk 알고리즘으로 실제 경로 생성
+    3단계: 두 결과를 합쳐 응답 반환
+
+    Args:
+        lat, lng    : 출발점 위경도
+        target_km   : 목표 거리 (km, 기본 5km)
+        radius_m    : DB 코스 검색 반경 (미터)
+        G           : 미리 로드된 NetworkX 그래프 (없으면 DB에서 로드)
+
+    Returns:
+        {
+            "mode": "circular_running",
+            "coordinates": [[lat, lng], ...],
+            "total_distance_km": float,
+            "matched_courses": [...]   # 반경 내 추천 코스 목록
+        }
+    """
+    t0 = time.time()
+
+    # ── 1. DB 코스 조회 ────────────────────────────────────────
+    matched_courses = get_courses_near(
+        lat=lat,
+        lng=lng,
+        radius_m=radius_m,
+        is_circular=True,
+        course_types=RUNNING_COURSE_TYPES,
+        tags=RUNNING_TAGS,
+        limit=5,
+    )
+    print(f"[running/circular] DB 코스 {len(matched_courses)}건 조회 ({time.time()-t0:.2f}s)")
+
+    # ── 2. 그래프 로드 ─────────────────────────────────────────
+    t1 = time.time()
+    graph_radius = target_km * 1000 * 2.5  # 목표 거리의 2.5배 반경
+    if G is None:
+        G = load_graph_near(lat, lng, radius_m=graph_radius)
+    print(f"[running/circular] 그래프 로드 ({time.time()-t1:.2f}s)")
+
+    if G.number_of_nodes() == 0:
+        return {
+            "mode": "circular_running",
+            "coordinates": [],
+            "total_distance_km": 0.0,
+            "matched_courses": matched_courses,
+            "error": "해당 위치 주변에 경로 데이터가 없습니다.",
+        }
+
+    # ── 3. 좌표 없는 노드 제거 (KeyError 방지) ────────────────
+    invalid_nodes = [n for n, d in G.nodes(data=True) if "x" not in d or "y" not in d]
+    if invalid_nodes:
+        G = G.copy()
+        G.remove_nodes_from(invalid_nodes)
+        print(f"[running/circular] 좌표 없는 노드 {len(invalid_nodes)}개 제거")
+
+    if G.number_of_nodes() == 0:
+        return {
+            "mode": "circular_running",
+            "coordinates": [],
+            "total_distance_km": 0.0,
+            "matched_courses": matched_courses,
+            "error": "유효한 노드가 없습니다.",
+        }
+
+    # ── 4. 런닝 가중치 적용 ────────────────────────────────────
+    G = _apply_running_weights(G)
+
+    # ── 5. 순환 경로 생성 ──────────────────────────────────────
+    t2 = time.time()
+    start_node = find_nearest_node(G, lat, lng)
+    raw = random_walk_route(G, start_node, target_km, weight="custom_score")
+    print(f"[running/circular] 경로 생성 ({time.time()-t2:.2f}s)")
+
+    result = _build_result(G, raw["nodes"], "circular_running", matched_courses)
+    print(f"[running/circular] 총 소요 {time.time()-t0:.2f}s")
+    return result
+
+
+def get_oneway_route(
+    start_lat: float,
+    start_lng: float,
+    end_lat: float,
+    end_lng: float,
+    target_km: Optional[float] = None,
+    use_random: bool = True,
+    radius_m: float = 5_000,
+    G: Optional[nx.Graph] = None,
+) -> dict:
+    """
+    출발점 → 도착점 편도 런닝 코스를 반환합니다.
+
+    1단계: DB에서 출발점 반경 내 편도 코스(하천변·공원) 조회
+    2단계: 그래프 기반 경로 알고리즘으로 실제 경로 생성
+           - use_random=True  → oneway_random (우회 경로, 더 긴 거리)
+           - use_random=False → dijkstra (최단 경로)
+    3단계: 두 결과를 합쳐 응답 반환
+
+    Args:
+        start_lat, start_lng : 출발점 위경도
+        end_lat, end_lng     : 도착점 위경도
+        target_km            : 목표 거리 (km, use_random=True 일 때만 사용)
+        use_random           : True=우회 경로, False=최단 경로
+        radius_m             : DB 코스 검색 반경 (미터)
+        G                    : 미리 로드된 NetworkX 그래프
+
+    Returns:
+        {
+            "mode": "oneway_running_random" | "oneway_running_shortest",
+            "coordinates": [[lat, lng], ...],
+            "total_distance_km": float,
+            "matched_courses": [...]
+        }
+    """
+    t0 = time.time()
+
+    # ── 1. DB 코스 조회 ────────────────────────────────────────
+    matched_courses = get_courses_near(
+        lat=start_lat,
+        lng=start_lng,
+        radius_m=radius_m,
+        is_circular=False,
+        course_types=RUNNING_COURSE_TYPES,
+        tags=RUNNING_TAGS,
+        limit=5,
+    )
+    print(f"[running/oneway] DB 코스 {len(matched_courses)}건 조회 ({time.time()-t0:.2f}s)")
+
+    # ── 2. 그래프 로드 ─────────────────────────────────────────
+    t1 = time.time()
+    import math
+    straight_m = math.sqrt(
+        (start_lat - end_lat) ** 2 + (start_lng - end_lng) ** 2
+    ) * 111_000  # 위도 1도 ≈ 111km
+    graph_radius = max(straight_m * 1.5, 3_000)  # 직선 거리의 1.5배, 최소 3km
+
+    if G is None:
+        # 출발·도착 중간 지점 기준으로 로드
+        mid_lat = (start_lat + end_lat) / 2
+        mid_lng = (start_lng + end_lng) / 2
+        G = load_graph_near(mid_lat, mid_lng, radius_m=graph_radius)
+    print(f"[running/oneway] 그래프 로드 ({time.time()-t1:.2f}s)")
+
+    if G.number_of_nodes() == 0:
+        return {
+            "mode": "oneway_running",
+            "coordinates": [],
+            "total_distance_km": 0.0,
+            "matched_courses": matched_courses,
+            "error": "해당 위치 주변에 경로 데이터가 없습니다.",
+        }
+
+    # ── 3. 좌표 없는 노드 제거 (KeyError 방지) ────────────────
+    invalid_nodes = [n for n, d in G.nodes(data=True) if "x" not in d or "y" not in d]
+    if invalid_nodes:
+        G = G.copy()
+        G.remove_nodes_from(invalid_nodes)
+        print(f"[running/oneway] 좌표 없는 노드 {len(invalid_nodes)}개 제거")
+
+    if G.number_of_nodes() == 0:
+        return {
+            "mode": "oneway_running",
+            "coordinates": [],
+            "total_distance_km": 0.0,
+            "matched_courses": matched_courses,
+            "error": "유효한 노드가 없습니다.",
+        }
+
+    # ── 4. 런닝 가중치 적용 ────────────────────────────────────
+    G = _apply_running_weights(G)
+
+    # ── 4. 편도 경로 생성 ──────────────────────────────────────
+    t2 = time.time()
+    start_node = find_nearest_node(G, start_lat, start_lng)
+    end_node   = find_nearest_node(G, end_lat, end_lng)
+
+    if use_random and target_km:
+        raw = oneway_random_route(G, start_node, end_node, target_km, weight="custom_score")
+        mode_label = "oneway_running_random"
+    else:
+        raw = dijkstra_route(G, start_node, end_node, weight="custom_score")
+        mode_label = "oneway_running_shortest"
+
+    print(f"[running/oneway] 경로 생성 ({time.time()-t2:.2f}s)")
+
+    result = _build_result(G, raw["nodes"], mode_label, matched_courses)
+    print(f"[running/oneway] 총 소요 {time.time()-t0:.2f}s")
+    return result


### PR DESCRIPTION
## ☝️Issue Number
- resolve #64

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 런닝/다이어트 모드 순환/편도 경로 추천 기능 구현
- 하천(35건), 공원(15건), 둘레길(21건), 자전거도로(281건) 총 352건 DB 적재
- POST /api/running/circular, POST /api/running/oneway API 구현
- 테스트용 running_app.py 추가 (app.py 충돌 방지 목적)
- Course, CourseTag 엔티티 및 레포지토리 추가

새로 생성:
- src/entity/course.py
- src/schema/running_schema.py
- src/data/collectors/running_course_collector.py
- src/repository/course_repository.py
- src/service/route/running_route_service.py
- src/api/running_router.py
- running_app.py
- src/data/collectors/running_course_migration.py

수정:
- src/main.py (running_router 등록)

## 🛠️ 테스트 방법
1. `src/data/raw/` 폴더에 아래 파일 위치 확인
   - 서울시 주요 공원현황.xlsx
   - 서울 둘레길.csv
   - 서울시 하천.geojson
   - 서울시 자전거도로.csv
2. 마이그레이션 실행
   python -m src.data.collectors.running_course_migration
3. FastAPI 서버 실행
   python -m uvicorn src.main:app --reload --port 8080
4. 테스트 앱 실행
   streamlit run running_app.py --server.port 8502
   
## ❗ 미구현 (추후 과제)
- app.py UI 연동
- 경로 직선 연결 → 실제 도로 그래프 기반으로 개선 필요
- 신호등 없는 구간 필터링 미구현