### PR TITLE
[FEAT] OSM 녹지 데이터 기반 nature_score 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ poetry run streamlit run app.py
 ```
 > 실행 후 브라우저에서 `http://localhost:8501`로 접속하여 확인할 수 있습니다.
 
+### 4. 데이터 초기화 (Data Setup)
+```bash
+# OSM 녹지 데이터 적재 (최초 1회)
+poetry run python data/collectors/fetch_osm_green.py
+⚠️ osmnx, geopandas 패키지 필요. poetry install 후 실행하세요.
+
 ---
 
 ## 🌿 깃/브랜치 전략 (Git Strategy)

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ from src.database.postgresql import health_check
 from src.client.weather_client import get_environment_info
 from src.service.route.route_service import get_route
 from src.service.route.child_walk_route import get_child_friendly_route
-from src.repository.graph_repository import load_graph
+from src.repository.graph_repository_v2 import load_graph_v2 as load_graph
 from src.service.map_service import fetch_local_db_lines_optimized, fetch_local_db_points
 from src.service.banner_service import get_banner
 from streamlit.components.v1 import html as st_html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,6 @@ services:
       - "5434:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    image: postgres:15
-  valkey:
-      image: valkey/valkey:latest
-      ports:
-        - "6379:6379"
-
   valkey:
     image: redis:7-alpine
     ports:

--- a/src/data/collectors/osm_green_collector.py
+++ b/src/data/collectors/osm_green_collector.py
@@ -1,0 +1,38 @@
+import osmnx as ox
+import geopandas as gpd
+import pandas as pd
+from pathlib import Path
+from dotenv import load_dotenv
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+load_dotenv(dotenv_path=Path(__file__).parent / ".env", encoding="utf-8")
+
+from src.database.postgresql import engine  # 기존 engine 재사용
+
+TAG_CONFIG = [
+    ({"natural": ["wood", "scrub"], "landuse": ["forest"]}, 3),
+    ({"leisure": ["park", "garden"], "landuse": ["grass", "meadow"]}, 2),
+    ({"landuse": ["farmland", "allotments"]}, 1),
+]
+
+frames = []
+for tags, weight in TAG_CONFIG:
+    for key, values in tags.items():
+        for val in values:
+            try:
+                gdf = ox.features_from_place("Seoul, South Korea", tags={key: val})
+                gdf = gdf[gdf.geometry.geom_type.isin(["Polygon", "MultiPolygon"])].copy()
+                gdf["osm_id"] = gdf.index.get_level_values("osmid")
+                gdf["green_type"] = val
+                gdf["green_weight"] = weight
+                gdf["name"] = gdf["name"] if "name" in gdf.columns else None
+                frames.append(gdf[["osm_id", "green_type", "green_weight", "name", "geometry"]])
+                print(f"{key}={val}: {len(gdf)}개")
+            except Exception as e:
+                print(f"{key}={val} 실패: {e}")
+
+combined = gpd.GeoDataFrame(pd.concat(frames, ignore_index=True), crs="EPSG:4326")
+combined.to_postgis("osm_green_areas", engine, if_exists="append", index=False)
+print(f"총 {len(combined)}개 폴리곤 저장 완료")

--- a/src/data/collectors/update_nature_score.py
+++ b/src/data/collectors/update_nature_score.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from sqlalchemy import text
+from src.database.postgresql import engine
+
+with engine.begin() as conn:
+    print("1단계: 전체 nature_score 1.0으로 초기화...", flush=True)
+    conn.execute(text("UPDATE walk_edges SET nature_score = 1.0"))
+    print("완료", flush=True)
+
+with engine.begin() as conn:
+    print("2단계: 녹지 근처 엣지만 업데이트 중...", flush=True)
+    result = conn.execute(text("""
+        UPDATE walk_edges we
+        SET nature_score = best.score
+        FROM (
+            SELECT we2.link_id,
+                   MAX(
+                       CASE
+                           WHEN ST_DWithin(og.geometry, we2.geom, 0.00027) THEN 1.0 + (og.green_weight / 3.0)
+                           WHEN ST_DWithin(og.geometry, we2.geom, 0.0009)  THEN 1.0 + (og.green_weight / 3.0) * 0.6
+                           WHEN ST_DWithin(og.geometry, we2.geom, 0.00225) THEN 1.0 + (og.green_weight / 3.0) * 0.3
+                       END
+                   ) AS score
+            FROM walk_edges we2
+            JOIN osm_green_areas og ON ST_DWithin(og.geometry, we2.geom, 0.00225)
+            GROUP BY we2.link_id
+        ) best
+        WHERE we.link_id = best.link_id
+    """))
+    print(f"완료: {result.rowcount}개 엣지 업데이트", flush=True)

--- a/src/service/route/route_service.py
+++ b/src/service/route/route_service.py
@@ -1,6 +1,6 @@
 # src/service/route_service.py
 import networkx as nx
-from src.repository.route.graph_repository import load_graph_near
+from src.repository.graph_repository_v2 import load_graph_near_v2 as load_graph_near
 from src.service.route.path_utils import find_nearest_node, extract_coordinates, prune_dead_ends
 from src.service.route.path_circular_random import random_walk_route
 from src.service.route.path_oneway_dijkstra import dijkstra_route


### PR DESCRIPTION
## ☝️Issue Number
- resolve #65 


## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- OSM 녹지 폴리곤 데이터를 기반으로 `walk_edges.nature_score`를 재산출하여 기존 `poi_layer` 기반 방식의 낮은 커버리지 문제를 해결

## 🔍 변경 사항
- `osmnx`로 서울 OSM 녹지 폴리곤 fetch 스크립트 작성
- `osm_green_areas` 테이블 생성 및 데이터 적재
- GIST 인덱스 생성으로 공간 쿼리 성능 확보
- `ST_DWithin` 기반 반경별(30m / 100m / 250m) 근접 녹지 가중치 적용하여 `nature_score` 업데이트 (1.0 ~ 2.0)

## 🌿 녹지 분류 기준
| 분류 | 태그 | 가중치 |
|------|------|--------|
| 진한 녹색 | `natural=wood/scrub`, `landuse=forest` | 3 |
| 중간 녹색 | `leisure=park/garden`, `landuse=grass/meadow` | 2 |
| 연한 녹색 | `landuse=farmland/allotments` | 1 |

## ✅ 검증
- `nature_score` avg / min / max 확인 완료

## 📌 참고
- `osmnx`, `geopandas` 패키지 필요
- `walk_edges.geom`: ST_LineString (EPSG:4326)