### PR TITLE
[Refactor] app.py 2단계 모듈화 — providers/header 분리

### DIFF
--- a/frontend/streamlit_prototype/app.py
+++ b/frontend/streamlit_prototype/app.py
@@ -1,37 +1,24 @@
 import config.path_setup  # noqa: F401 — must precede all src/ imports
 
-import time
 import streamlit as st
 
 from frontend.streamlit_prototype.bootstrap import create_app_context, AppContext
 from frontend.streamlit_prototype.sections.page_setup import setup_page
+from frontend.streamlit_prototype.sections.header import render_header
 
 
 class App:
 
     def __init__(self):
-        ctx: AppContext          = create_app_context()
-        self._weather_card       = ctx.weather_card
-        self._banner_data        = ctx.banner_data
-        self._banner_carousel    = ctx.banner_carousel
-        self._chat_panel         = ctx.chat_panel
-        self._coordinate_panel   = ctx.coordinate_panel
-        self._walk_result_panel  = ctx.walk_result_panel
-        self._walk_sidebar       = ctx.walk_sidebar
-        self._walk_route_map     = ctx.walk_route_map
-        self._walk_route_button  = ctx.walk_route_button
+        self._ctx: AppContext = create_app_context()
 
     def run(self) -> None:
-        setup_page(self._walk_route_map)
+        ctx = self._ctx
+        setup_page(ctx.walk_route_map)
 
-        t = time.time()
-        lat, lng = self._walk_route_map.get_location()
-        env      = self._weather_card.fetch(lat, lng)
-        banners  = self._banner_data.get_banner_list(env)
-        self._banner_carousel.render(banners)
-        print(f"weather+banner: {time.time()-t:.2f}s")
+        lat, lng, env = render_header(ctx)
 
-        config         = self._walk_sidebar.render()
+        config         = ctx.walk_sidebar.render()
         input_mode     = config["input_mode"]
         selected_mode  = config["selected_mode"]
         distance_km    = config["distance_km"]
@@ -39,21 +26,21 @@ class App:
         safety_w       = config["safety_w"]
         nature_w       = config["nature_w"]
 
-        self._weather_card.render(env)
+        ctx.weather_card.render(env)
 
         if input_mode == "AI 챗봇":
-            updated = self._chat_panel.render(selected_mode, distance_km, safety_w, nature_w)
+            updated = ctx.chat_panel.render(selected_mode, distance_km, safety_w, nature_w)
             if updated:
                 safety_w, nature_w, selected_mode, distance_km = updated
 
-        self._walk_route_map.init_session_state()
-        self._walk_route_map.render(input_mode)
-        self._coordinate_panel.render()
+        ctx.walk_route_map.init_session_state()
+        ctx.walk_route_map.render(input_mode)
+        ctx.coordinate_panel.render()
 
         if st.session_state.get("route_result"):
-            self._walk_result_panel.render(st.session_state.route_result)
+            ctx.walk_result_panel.render(st.session_state.route_result)
 
-        self._walk_route_button.render(
+        ctx.walk_route_button.render(
             input_mode, selected_mode, distance_km, child_friendly, safety_w, nature_w, lat, lng
         )
 

--- a/frontend/streamlit_prototype/bootstrap.py
+++ b/frontend/streamlit_prototype/bootstrap.py
@@ -5,7 +5,6 @@ import streamlit as st
 
 from src.repository.network.graph_repository import GraphRepository
 from frontend.streamlit_prototype.components.card.weather_card import WeatherCard
-from frontend.streamlit_prototype.components.carousel.banner_data_carousel import BannerDataCarousel
 from frontend.streamlit_prototype.components.carousel.banner_carousel import BannerCarousel
 from frontend.streamlit_prototype.components.panel.chat_panel import ChatPanel
 from frontend.streamlit_prototype.components.panel.coordinate_panel import CoordinatePanel
@@ -13,6 +12,8 @@ from frontend.streamlit_prototype.components.panel.walk_result_panel import Walk
 from frontend.streamlit_prototype.components.sidebar.walk_sidebar import WalkSidebar
 from frontend.streamlit_prototype.components.map.walk_route_map import WalkRouteMap
 from frontend.streamlit_prototype.components.button.walk_route_button import WalkRouteButton
+from frontend.streamlit_prototype.providers.base import EnvProvider
+from frontend.streamlit_prototype.providers.registry import build_provider
 
 
 @st.cache_resource
@@ -25,7 +26,6 @@ def _load_graph():
 @dataclass
 class AppContext:
     weather_card:      WeatherCard
-    banner_data:       BannerDataCarousel
     banner_carousel:   BannerCarousel
     chat_panel:        ChatPanel
     coordinate_panel:  CoordinatePanel
@@ -33,6 +33,7 @@ class AppContext:
     walk_sidebar:      WalkSidebar
     walk_route_map:    WalkRouteMap
     walk_route_button: WalkRouteButton
+    provider:          EnvProvider
 
 
 def create_app_context() -> AppContext:
@@ -42,7 +43,6 @@ def create_app_context() -> AppContext:
 
     return AppContext(
         weather_card      = WeatherCard(),
-        banner_data       = BannerDataCarousel(),
         banner_carousel   = BannerCarousel(),
         chat_panel        = ChatPanel(),
         coordinate_panel  = CoordinatePanel(),
@@ -50,4 +50,5 @@ def create_app_context() -> AppContext:
         walk_sidebar      = WalkSidebar(),
         walk_route_map    = WalkRouteMap(G),
         walk_route_button = WalkRouteButton(G),
+        provider          = build_provider(),
     )

--- a/frontend/streamlit_prototype/components/card/weather_card.py
+++ b/frontend/streamlit_prototype/components/card/weather_card.py
@@ -3,6 +3,7 @@ import asyncio
 import streamlit as st
 
 from frontend.streamlit_prototype.api.weather_router import WeatherRouter
+from frontend.streamlit_prototype.providers.base import EnvData
 
 
 @st.cache_data(ttl=300)
@@ -36,14 +37,14 @@ class WeatherCard:
         """
         return _fetch_weather(lat, lng)
 
-    def render(self, env: dict):
+    def render(self, env: EnvData) -> None:
         """
         날씨, 미세먼지, 추천 경로 수 지표를 3열로 렌더링합니다.
         """
         col1, col2, col3 = st.columns(3)
         with col1:
-            st.metric("현재 날씨", env["weather_status"], env["weather_msg"])
+            st.metric("현재 날씨", env.weather_status, env.weather_msg)
         with col2:
-            st.metric("미세먼지", env["air_status"], env["air_msg"])
+            st.metric("미세먼지", env.air_status, env.air_msg)
         with col3:
             st.metric("추천 경로", "3개", "평균 3.2km")

--- a/frontend/streamlit_prototype/providers/base.py
+++ b/frontend/streamlit_prototype/providers/base.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class EnvData:
+    weather_status: str
+    weather_msg:    str
+    air_status:     str
+    air_msg:        str
+
+
+class EnvProvider(ABC):
+
+    @abstractmethod
+    def fetch(self, lat: float, lng: float) -> EnvData: ...
+
+    @abstractmethod
+    def get_banners(self, env: EnvData) -> list: ...

--- a/frontend/streamlit_prototype/providers/registry.py
+++ b/frontend/streamlit_prototype/providers/registry.py
@@ -1,0 +1,6 @@
+from frontend.streamlit_prototype.providers.base import EnvProvider
+from frontend.streamlit_prototype.providers.weather_api import WeatherEnvProvider
+
+
+def build_provider() -> EnvProvider:
+    return WeatherEnvProvider()

--- a/frontend/streamlit_prototype/providers/weather_api.py
+++ b/frontend/streamlit_prototype/providers/weather_api.py
@@ -1,0 +1,23 @@
+import dataclasses
+
+from frontend.streamlit_prototype.components.card.weather_card import _fetch_weather
+from frontend.streamlit_prototype.components.carousel.banner_data_carousel import BannerDataCarousel
+from frontend.streamlit_prototype.providers.base import EnvData, EnvProvider
+
+
+class WeatherEnvProvider(EnvProvider):
+
+    def __init__(self):
+        self._banner_data = BannerDataCarousel()
+
+    def fetch(self, lat: float, lng: float) -> EnvData:
+        raw = _fetch_weather(lat, lng)
+        return EnvData(
+            weather_status=raw["weather_status"],
+            weather_msg=raw["weather_msg"],
+            air_status=raw["air_status"],
+            air_msg=raw["air_msg"],
+        )
+
+    def get_banners(self, env: EnvData) -> list:
+        return self._banner_data.get_banner_list(dataclasses.asdict(env))

--- a/frontend/streamlit_prototype/sections/header.py
+++ b/frontend/streamlit_prototype/sections/header.py
@@ -1,0 +1,14 @@
+import time
+
+from frontend.streamlit_prototype.bootstrap import AppContext
+from frontend.streamlit_prototype.providers.base import EnvData
+
+
+def render_header(ctx: AppContext) -> tuple[float, float, EnvData]:
+    t = time.time()
+    lat, lng = ctx.walk_route_map.get_location()
+    env      = ctx.provider.fetch(lat, lng)
+    banners  = ctx.provider.get_banners(env)
+    ctx.banner_carousel.render(banners)
+    print(f"weather+banner: {time.time()-t:.2f}s")
+    return lat, lng, env


### PR DESCRIPTION
## ☝️Issue Number
- resolve #95

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
app.py 리팩토링 2단계 — 외부 API 제공자(Provider) 구조 분리

## 파일별 기능 설명
- `providers/base.py` : EnvData dataclass와 EnvProvider 추상 클래스 정의
- `providers/weather_api.py` : 날씨 fetch + 배너 생성 로직을 WeatherEnvProvider로 통합
- `providers/registry.py` : 활성 Provider 인스턴스를 반환하는 build_provider() 팩토리
- `sections/header.py` : 위치 조회 → Provider 호출 → 배너 렌더링을 render_header(ctx)로 묶음
- `bootstrap.py` : AppContext에서 BannerDataCarousel 제거, EnvProvider 필드 추가
- `weather_card.py` : render() 인자를 dict에서 EnvData로 변경
- `app.py` : __init__ 한 줄로 축소, run() 내 weather+banner 블록을 render_header() 한 줄로 교체