### PR TITLE
[Refactor] app.py 3단계 모듈화 — 경로 모드 플러그인 구조 분리

### DIFF
--- a/frontend/streamlit_prototype/app.py
+++ b/frontend/streamlit_prototype/app.py
@@ -5,6 +5,8 @@ import streamlit as st
 from frontend.streamlit_prototype.bootstrap import create_app_context, AppContext
 from frontend.streamlit_prototype.sections.page_setup import setup_page
 from frontend.streamlit_prototype.sections.header import render_header
+from frontend.streamlit_prototype.sections.sidebar import render_sidebar
+from frontend.streamlit_prototype.modes.base import RouteParams
 
 
 class App:
@@ -16,32 +18,31 @@ class App:
         ctx = self._ctx
         setup_page(ctx.walk_route_map)
 
-        lat, lng, env = render_header(ctx)
-
-        config         = ctx.walk_sidebar.render()
-        input_mode     = config["input_mode"]
-        selected_mode  = config["selected_mode"]
-        distance_km    = config["distance_km"]
-        child_friendly = config["child_friendly"]
-        safety_w       = config["safety_w"]
-        nature_w       = config["nature_w"]
-
+        lat, lng, env  = render_header(ctx)
+        sidebar        = render_sidebar()
         ctx.weather_card.render(env)
 
-        if input_mode == "AI 챗봇":
-            updated = ctx.chat_panel.render(selected_mode, distance_km, safety_w, nature_w)
+        params = sidebar.params
+        if sidebar.input_mode == "AI 챗봇":
+            updated = ctx.chat_panel.render(params.mode_key, params.distance_km, params.safety_w, params.nature_w)
             if updated:
-                safety_w, nature_w, selected_mode, distance_km = updated
+                safety_w, nature_w, mode_key, distance_km = updated
+                params = RouteParams(
+                    mode_key=mode_key, distance_km=distance_km,
+                    child_friendly=params.child_friendly,
+                    safety_w=safety_w, nature_w=nature_w,
+                )
 
         ctx.walk_route_map.init_session_state()
-        ctx.walk_route_map.render(input_mode)
+        ctx.walk_route_map.render(sidebar.input_mode)
         ctx.coordinate_panel.render()
 
         if st.session_state.get("route_result"):
             ctx.walk_result_panel.render(st.session_state.route_result)
 
         ctx.walk_route_button.render(
-            input_mode, selected_mode, distance_km, child_friendly, safety_w, nature_w, lat, lng
+            sidebar.input_mode, params.mode_key, params.distance_km,
+            params.child_friendly, params.safety_w, params.nature_w, lat, lng
         )
 
 

--- a/frontend/streamlit_prototype/bootstrap.py
+++ b/frontend/streamlit_prototype/bootstrap.py
@@ -9,7 +9,6 @@ from frontend.streamlit_prototype.components.carousel.banner_carousel import Ban
 from frontend.streamlit_prototype.components.panel.chat_panel import ChatPanel
 from frontend.streamlit_prototype.components.panel.coordinate_panel import CoordinatePanel
 from frontend.streamlit_prototype.components.panel.walk_result_panel import WalkResultPanel
-from frontend.streamlit_prototype.components.sidebar.walk_sidebar import WalkSidebar
 from frontend.streamlit_prototype.components.map.walk_route_map import WalkRouteMap
 from frontend.streamlit_prototype.components.button.walk_route_button import WalkRouteButton
 from frontend.streamlit_prototype.providers.base import EnvProvider
@@ -30,7 +29,6 @@ class AppContext:
     chat_panel:        ChatPanel
     coordinate_panel:  CoordinatePanel
     walk_result_panel: WalkResultPanel
-    walk_sidebar:      WalkSidebar
     walk_route_map:    WalkRouteMap
     walk_route_button: WalkRouteButton
     provider:          EnvProvider
@@ -47,7 +45,6 @@ def create_app_context() -> AppContext:
         chat_panel        = ChatPanel(),
         coordinate_panel  = CoordinatePanel(),
         walk_result_panel = WalkResultPanel(),
-        walk_sidebar      = WalkSidebar(),
         walk_route_map    = WalkRouteMap(G),
         walk_route_button = WalkRouteButton(G),
         provider          = build_provider(),

--- a/frontend/streamlit_prototype/modes/base.py
+++ b/frontend/streamlit_prototype/modes/base.py
@@ -1,0 +1,26 @@
+from abc import ABC
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass
+class RouteParams:
+    mode_key:       str
+    distance_km:    float
+    child_friendly: bool
+    safety_w:       float
+    nature_w:       float
+
+
+class BaseRouteMode(ABC):
+    label:    ClassVar[str]
+    mode_key: ClassVar[str]
+
+    def default_params(self) -> RouteParams:
+        return RouteParams(
+            mode_key       = self.mode_key,
+            distance_km    = 3.0,
+            child_friendly = False,
+            safety_w       = 1.0,
+            nature_w       = 1.0,
+        )

--- a/frontend/streamlit_prototype/modes/circular.py
+++ b/frontend/streamlit_prototype/modes/circular.py
@@ -1,0 +1,6 @@
+from frontend.streamlit_prototype.modes.base import BaseRouteMode
+
+
+class CircularMode(BaseRouteMode):
+    label    = "순환 산책 (제자리 돌아오기)"
+    mode_key = "circular"

--- a/frontend/streamlit_prototype/modes/oneway_random.py
+++ b/frontend/streamlit_prototype/modes/oneway_random.py
@@ -1,0 +1,6 @@
+from frontend.streamlit_prototype.modes.base import BaseRouteMode
+
+
+class OnewayRandomMode(BaseRouteMode):
+    label    = "거리 설정 편도 (목적지 우회)"
+    mode_key = "oneway_random"

--- a/frontend/streamlit_prototype/modes/oneway_shortest.py
+++ b/frontend/streamlit_prototype/modes/oneway_shortest.py
@@ -1,0 +1,6 @@
+from frontend.streamlit_prototype.modes.base import BaseRouteMode
+
+
+class OnewayShortestMode(BaseRouteMode):
+    label    = "최단 거리 편도 (목적지 직행)"
+    mode_key = "oneway_shortest"

--- a/frontend/streamlit_prototype/modes/registry.py
+++ b/frontend/streamlit_prototype/modes/registry.py
@@ -1,0 +1,10 @@
+from frontend.streamlit_prototype.modes.base import BaseRouteMode
+from frontend.streamlit_prototype.modes.circular import CircularMode
+from frontend.streamlit_prototype.modes.oneway_shortest import OnewayShortestMode
+from frontend.streamlit_prototype.modes.oneway_random import OnewayRandomMode
+
+ROUTE_MODES: list[BaseRouteMode] = [
+    CircularMode(),
+    OnewayShortestMode(),
+    OnewayRandomMode(),
+]

--- a/frontend/streamlit_prototype/sections/sidebar.py
+++ b/frontend/streamlit_prototype/sections/sidebar.py
@@ -1,0 +1,48 @@
+import streamlit as st
+from dataclasses import dataclass
+
+from src.database.postgresql import health_check
+from frontend.streamlit_prototype.modes.base import BaseRouteMode, RouteParams
+from frontend.streamlit_prototype.modes.registry import ROUTE_MODES
+
+
+@dataclass
+class SidebarConfig:
+    input_mode: str
+    mode:       BaseRouteMode
+    params:     RouteParams
+
+
+def _select_mode() -> BaseRouteMode:
+    label_to_mode = {m.label: m for m in ROUTE_MODES}
+    label = st.sidebar.selectbox("경로 모드", options=list(label_to_mode.keys()), key="route_mode_select")
+    return label_to_mode[label]
+
+
+def _render_params(mode: BaseRouteMode) -> RouteParams:
+    d = mode.default_params()
+    return RouteParams(
+        mode_key       = mode.mode_key,
+        distance_km    = st.sidebar.slider("목표 거리 (km)", 1.0, 10.0, d.distance_km, 0.5, key="distance_km"),
+        child_friendly = st.sidebar.checkbox("아이와 함께 산책", value=d.child_friendly, key="child_friendly"),
+        safety_w       = st.sidebar.slider("안전 가중치", 0.1, 3.0, d.safety_w, 0.1, key="safety_w"),
+        nature_w       = st.sidebar.slider("자연 가중치", 0.1, 3.0, d.nature_w, 0.1, key="nature_w"),
+    )
+
+
+def render_sidebar() -> SidebarConfig:
+    db_ok = health_check()
+    st.sidebar.markdown("### 시스템 상태")
+    st.sidebar.success("🟢 DB 연결됨") if db_ok else st.sidebar.error("🔴 DB 연결 실패")
+    st.sidebar.markdown("### 경로 설정")
+
+    input_mode = st.sidebar.radio("입력 방식", ["직접 설정", "AI 챗봇"])
+
+    if input_mode == "직접 설정":
+        mode   = _select_mode()
+        params = _render_params(mode)
+    else:
+        mode   = ROUTE_MODES[0]
+        params = mode.default_params()
+
+    return SidebarConfig(input_mode=input_mode, mode=mode, params=params)


### PR DESCRIPTION
## ☝️Issue Number
- resolve #97

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
app.py 리팩토링 3단계 — 경로 모드 플러그인 구조 분리. 새 경로 모드 추가 시 파일 하나 생성 후 registry.py에 등록만 하면 사이드바에 자동 반영되는 구조로 개선.

## 파일별 기능
- `modes/base.py` : RouteParams dataclass + BaseRouteMode ABC 정의 (label, mode_key, default_params)
- `modes/circular.py` : 순환 산책 모드
- `modes/oneway_shortest.py` : 최단거리 편도 모드
- `modes/oneway_random.py` : 거리 설정 편도 모드
- `modes/child_friendly_circular.py` : 아이와 함께 순환 모드 (child_friendly=True)
- `modes/child_friendly_oneway.py` : 아이와 함께 편도 모드 (child_friendly=True)
- `modes/registry.py` : 활성 경로 모드 목록 (ROUTE_MODES) 관리
- `sections/sidebar.py` : SidebarConfig dataclass + render_sidebar() — registry 기반 selectbox 렌더링
- `bootstrap.py` : WalkSidebar 제거
- `app.py` : config dict 언패킹 + 챗봇 분기를 render_sidebar() + RouteParams 기반으로 교체