### PR TITLE
[Refactor] app.py 4단계 모듈화 — map/result 섹션 분리 및 run() 정리

### DIFF
--- a/frontend/streamlit_prototype/app.py
+++ b/frontend/streamlit_prototype/app.py
@@ -1,12 +1,11 @@
 import config.path_setup  # noqa: F401 — must precede all src/ imports
 
-import streamlit as st
-
 from frontend.streamlit_prototype.bootstrap import create_app_context, AppContext
 from frontend.streamlit_prototype.sections.page_setup import setup_page
 from frontend.streamlit_prototype.sections.header import render_header
-from frontend.streamlit_prototype.sections.sidebar import render_sidebar
-from frontend.streamlit_prototype.modes.base import RouteParams
+from frontend.streamlit_prototype.sections.sidebar import render_sidebar, apply_input_mode
+from frontend.streamlit_prototype.sections.map_section import render_map
+from frontend.streamlit_prototype.sections.result_section import render_result
 
 
 class App:
@@ -15,35 +14,14 @@ class App:
         self._ctx: AppContext = create_app_context()
 
     def run(self) -> None:
-        ctx = self._ctx
+        ctx           = self._ctx
         setup_page(ctx.walk_route_map)
-
-        lat, lng, env  = render_header(ctx)
-        sidebar        = render_sidebar()
+        lat, lng, env = render_header(ctx)
+        sidebar       = render_sidebar()
         ctx.weather_card.render(env)
-
-        params = sidebar.params
-        if sidebar.input_mode == "AI 챗봇":
-            updated = ctx.chat_panel.render(params.mode_key, params.distance_km, params.safety_w, params.nature_w)
-            if updated:
-                safety_w, nature_w, mode_key, distance_km = updated
-                params = RouteParams(
-                    mode_key=mode_key, distance_km=distance_km,
-                    child_friendly=params.child_friendly,
-                    safety_w=safety_w, nature_w=nature_w,
-                )
-
-        ctx.walk_route_map.init_session_state()
-        ctx.walk_route_map.render(sidebar.input_mode)
-        ctx.coordinate_panel.render()
-
-        if st.session_state.get("route_result"):
-            ctx.walk_result_panel.render(st.session_state.route_result)
-
-        ctx.walk_route_button.render(
-            sidebar.input_mode, params.mode_key, params.distance_km,
-            params.child_friendly, params.safety_w, params.nature_w, lat, lng
-        )
+        params        = apply_input_mode(ctx, sidebar)
+        render_map(ctx, sidebar)
+        render_result(ctx, sidebar, params, lat, lng)
 
 
 if __name__ == "__main__":

--- a/frontend/streamlit_prototype/sections/map_section.py
+++ b/frontend/streamlit_prototype/sections/map_section.py
@@ -1,0 +1,8 @@
+from frontend.streamlit_prototype.bootstrap import AppContext
+from frontend.streamlit_prototype.sections.sidebar import SidebarConfig
+
+
+def render_map(ctx: AppContext, sidebar: SidebarConfig) -> None:
+    ctx.walk_route_map.init_session_state()
+    ctx.walk_route_map.render(sidebar.input_mode)
+    ctx.coordinate_panel.render()

--- a/frontend/streamlit_prototype/sections/result_section.py
+++ b/frontend/streamlit_prototype/sections/result_section.py
@@ -1,0 +1,21 @@
+import streamlit as st
+
+from frontend.streamlit_prototype.bootstrap import AppContext
+from frontend.streamlit_prototype.modes.base import RouteParams
+from frontend.streamlit_prototype.sections.sidebar import SidebarConfig
+
+
+def render_result(
+    ctx:     AppContext,
+    sidebar: SidebarConfig,
+    params:  RouteParams,
+    lat:     float,
+    lng:     float,
+) -> None:
+    if st.session_state.get("route_result"):
+        ctx.walk_result_panel.render(st.session_state.route_result)
+
+    ctx.walk_route_button.render(
+        sidebar.input_mode, params.mode_key, params.distance_km,
+        params.child_friendly, params.safety_w, params.nature_w, lat, lng
+    )

--- a/frontend/streamlit_prototype/sections/sidebar.py
+++ b/frontend/streamlit_prototype/sections/sidebar.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from src.database.postgresql import health_check
 from frontend.streamlit_prototype.modes.base import BaseRouteMode, RouteParams
 from frontend.streamlit_prototype.modes.registry import ROUTE_MODES
+from frontend.streamlit_prototype.modes.base import RouteParams
 
 
 @dataclass
@@ -46,3 +47,23 @@ def render_sidebar() -> SidebarConfig:
         params = mode.default_params()
 
     return SidebarConfig(input_mode=input_mode, mode=mode, params=params)
+
+def apply_input_mode(ctx, sidebar: SidebarConfig) -> RouteParams:
+    params = sidebar.params
+    if sidebar.input_mode != "AI 챗봇":
+        return params
+
+    updated = ctx.chat_panel.render(
+        params.mode_key, params.distance_km, params.safety_w, params.nature_w
+    )
+    if not updated:
+        return params
+
+    safety_w, nature_w, mode_key, distance_km = updated
+    return RouteParams(
+        mode_key       = mode_key,
+        distance_km    = distance_km,
+        child_friendly = params.child_friendly,
+        safety_w       = safety_w,
+        nature_w       = nature_w,
+    )


### PR DESCRIPTION
## ☝️Issue Number
- resolve #102

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
app.py 리팩토링 4단계 — 지도·결과 섹션 분리 및 run() 최종 정리. run()이 섹션 함수 호출 8줄로 축소되어 렌더링 흐름만 표현하도록 마무리.

## 파일별 기능
- `sections/map_section.py` : render_map(ctx, sidebar) — 지도 초기화·렌더링·좌표 패널을 하나로 묶음
- `sections/result_section.py` : render_result(ctx, sidebar, params, lat, lng) — 경로 결과 패널 + 경로 추천 버튼 렌더링
- `sections/sidebar.py` : apply_input_mode(ctx, sidebar) 추가 — AI 챗봇 분기 로직 흡수
- `app.py` : `run()` 8줄로 축소, streamlit 직접 import 제거
