### PR TITLE
[Refactor] render_params() 각 모드로 이전 및 child_walk_route 임포트 수정

### DIFF
--- a/frontend/streamlit_prototype/components/button/walk_route_button.py
+++ b/frontend/streamlit_prototype/components/button/walk_route_button.py
@@ -1,9 +1,31 @@
 import streamlit as st
 
 from src.service.route.route_service import RouteService
-from src.route_engine.engines.child_walk_route import ChildWalkRoute
 from frontend.streamlit_prototype.schema.prewalk_schema import Weights
+from src.route_engine.engines.circular.child import circular_child_route
+from src.route_engine.engines.oneway.child import oneway_child_route
 
+def _get_child_route(context: dict, G) -> dict:
+    mode        = context.get("mode", "circular")
+    origin      = context["origin"]["coordinate"]
+    start_lat   = float(origin["lat"])
+    start_lon   = float(origin["lon"])
+    distance_km = float(context.get("distance_km", 3.0))
+
+    if mode == "circular":
+        return circular_child_route(G, start_lat, start_lon, distance_km)
+
+    destination = context.get("destination")
+    if not destination:
+        return {"error": "편도 모드에서는 도착지를 설정해야 합니다."}
+
+    end_coord = destination["coordinate"]
+    return oneway_child_route(
+        G, start_lat, start_lon,
+        float(end_coord["lat"]), float(end_coord["lon"]),
+        distance_km,
+        use_random=(mode == "oneway_random"),
+    )
 
 class WalkRouteButton:
 
@@ -65,7 +87,7 @@ class WalkRouteButton:
                     with st.spinner("최적의 경로를 계산하는 중..."):
                         context = self._build_context(selected_mode, distance_km, lat, lng)
                         result = (
-                            ChildWalkRoute().get_route(context, weights, self.G)
+                            _get_child_route(context, self.G)
                             if child_friendly
                             else self._route_service.get_route(context, weights, self.G)
                         )

--- a/frontend/streamlit_prototype/modes/base.py
+++ b/frontend/streamlit_prototype/modes/base.py
@@ -1,3 +1,4 @@
+import streamlit as st
 from abc import ABC
 from dataclasses import dataclass
 from typing import ClassVar
@@ -24,3 +25,14 @@ class BaseRouteMode(ABC):
             safety_w       = 1.0,
             nature_w       = 1.0,
         )
+
+    def render_params(self) -> RouteParams:
+        d = self.default_params()
+        return RouteParams(
+            mode_key       = self.mode_key,
+            distance_km    = st.sidebar.slider("목표 거리 (km)", 1.0, 10.0, d.distance_km, 0.5, key="distance_km"),
+            child_friendly = d.child_friendly,
+            safety_w       = d.safety_w,
+            nature_w       = d.nature_w,
+        )
+

--- a/frontend/streamlit_prototype/modes/oneway_shortest.py
+++ b/frontend/streamlit_prototype/modes/oneway_shortest.py
@@ -1,6 +1,11 @@
-from frontend.streamlit_prototype.modes.base import BaseRouteMode
+import streamlit as st
+
+from frontend.streamlit_prototype.modes.base import BaseRouteMode, RouteParams
 
 
 class OnewayShortestMode(BaseRouteMode):
     label    = "최단 거리 편도 (목적지 직행)"
     mode_key = "oneway_shortest"
+
+    def render_params(self) -> RouteParams:
+        return self.default_params()

--- a/frontend/streamlit_prototype/sections/sidebar.py
+++ b/frontend/streamlit_prototype/sections/sidebar.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from src.database.postgresql import health_check
 from frontend.streamlit_prototype.modes.base import BaseRouteMode, RouteParams
 from frontend.streamlit_prototype.modes.registry import ROUTE_MODES
-from frontend.streamlit_prototype.modes.base import RouteParams
 
 
 @dataclass
@@ -21,14 +20,7 @@ def _select_mode() -> BaseRouteMode:
 
 
 def _render_params(mode: BaseRouteMode) -> RouteParams:
-    d = mode.default_params()
-    return RouteParams(
-        mode_key       = mode.mode_key,
-        distance_km    = st.sidebar.slider("목표 거리 (km)", 1.0, 10.0, d.distance_km, 0.5, key="distance_km"),
-        child_friendly = st.sidebar.checkbox("아이와 함께 산책", value=d.child_friendly, key="child_friendly"),
-        safety_w       = st.sidebar.slider("안전 가중치", 0.1, 3.0, d.safety_w, 0.1, key="safety_w"),
-        nature_w       = st.sidebar.slider("자연 가중치", 0.1, 3.0, d.nature_w, 0.1, key="nature_w"),
-    )
+    return mode.render_params()
 
 
 def render_sidebar() -> SidebarConfig:
@@ -47,6 +39,7 @@ def render_sidebar() -> SidebarConfig:
         params = mode.default_params()
 
     return SidebarConfig(input_mode=input_mode, mode=mode, params=params)
+
 
 def apply_input_mode(ctx, sidebar: SidebarConfig) -> RouteParams:
     params = sidebar.params


### PR DESCRIPTION
## ☝️Issue Number
- resolve #104

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- BaseRouteMode에 render_params() 기본 구현 추가 (km 슬라이더만 노출)
- OnewayShortestMode.render_params() — UI 없이 default_params() 반환
- sidebar._render_params() → mode.render_params() 위임으로 단순화
- walk_route_button: ChildWalkRoute 제거, _get_child_route() 헬퍼로 대체