### PR TITLE
[Fix] GET /api/weather 응답 튜플 → EnvironmentInfo 수정

### DIFF
--- a/frontend/streamlit_prototype/components/card/weather_card.py
+++ b/frontend/streamlit_prototype/components/card/weather_card.py
@@ -19,7 +19,7 @@ def _fetch_weather(lat: float, lng: float) -> dict:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
         data = loop.run_until_complete(router.get_weather(lat, lng))
-        return data[0] if isinstance(data, list) else data
+        return data
     except Exception:
         return {
             "weather_status": "알 수 없음",

--- a/src/interfaces/api/weather_router.py
+++ b/src/interfaces/api/weather_router.py
@@ -16,4 +16,5 @@ async def get_weather(
     """
     현재 위치 기반 날씨와 대기질을 반환합니다.
     """
-    return await service.generate_init_message(lat, lon)
+    env_info, _ = await service.generate_init_message(lat, lon)
+    return env_info


### PR DESCRIPTION
## ☝️Issue Number
- resolve #119 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- `GET /api/weather` 엔드포인트가 `(EnvironmentInfo, str)` 튜플을 그대로 반환해 JSON 배열로 직렬화되던 문제 수정
- 라우터에서 튜플을 언패킹해 `EnvironmentInfo`만 반환하도록 변경하고, 프론트엔드의 `data[0]` 임시 처리 제거

