### PR TITLE
Feat/125 walk route api

### DIFF
--- a/frontend/streamlit_prototype/api/walk_router.py
+++ b/frontend/streamlit_prototype/api/walk_router.py
@@ -1,0 +1,14 @@
+import httpx
+
+from frontend.streamlit_prototype.api.base_url import base_url
+
+
+class WalkRouter:
+    def __init__(self):
+        self.base_url = f"{base_url}/api/walk/route"
+
+    async def post_route(self, payload: dict) -> dict:
+        """산책 경로 추천 API를 호출합니다."""
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(self.base_url, json=payload)
+            return response.json()

--- a/frontend/streamlit_prototype/components/button/walk_route_button.py
+++ b/frontend/streamlit_prototype/components/button/walk_route_button.py
@@ -1,68 +1,40 @@
 import streamlit as st
 
-from src.service.route.route_service import RouteService
-from src.route_engine.engines.circular.child import CircularChildEngine
-from src.route_engine.engines.oneway.child import OnewayChildEngine
-from src.route_engine.schema import CircularRouteInput, OnewayRouteInput
-
-def _get_child_route(context: dict, G) -> dict:
-    mode        = context.get("mode", "circular")
-    origin      = context["origin"]["coordinate"]
-    start_lat   = float(origin["lat"])
-    start_lon   = float(origin["lon"])
-    distance_km = float(context.get("distance_km", 3.0))
-
-    if mode == "circular":
-        inp    = CircularRouteInput(start_lat=start_lat, start_lon=start_lon, target_km=distance_km)
-        engine = CircularChildEngine(inp, G)
-    else:
-        destination = context.get("destination")
-        if not destination:
-            return {"error": "편도 모드에서는 도착지를 설정해야 합니다."}
-        end_coord = destination["coordinate"]
-        inp    = OnewayRouteInput(
-            start_lat=start_lat, start_lon=start_lon,
-            end_lat=float(end_coord["lat"]), end_lon=float(end_coord["lon"]),
-            target_km=distance_km,
-        )
-        engine = OnewayChildEngine(inp, G, use_random=(mode == "oneway_random"))
-
-    output = engine.run()
-    return {
-        "mode":              output.mode,
-        "coordinates":       output.coordinates,
-        "total_distance_km": output.total_km,
-        "child_index":       engine.child_index,
-        "child_profile":     engine.child_profile,
-        "error":             output.fallback_reason.value if output.fallback_reason else None,
-    }
+import asyncio
+from frontend.streamlit_prototype.api.walk_router import WalkRouter
 
 class WalkRouteButton:
 
     def __init__(self, G):
         self.G = G
-        self._route_service = RouteService()
+    
+    def _call_api(self, payload: dict) -> dict:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        return loop.run_until_complete(WalkRouter().post_route(payload))
 
     def _build_context(
-        self, selected_mode: str, distance_km: float, lat: float, lng: float
+        self, selected_mode: str, distance_km: float, child_friendly: bool, lat: float, lng: float
     ) -> dict:
-        """
-        경로 계산 API에 전달할 context 딕셔너리를 생성합니다.
-        """
         return {
-            "mode": selected_mode,
-            "distance_km": distance_km,
+            "mode":           selected_mode,
+            "distance_km":    distance_km,
+            "child_friendly": child_friendly,
             "origin": {
                 "place_name": "", "address": "",
                 "coordinate": {"lat": st.session_state.start[0], "lon": st.session_state.start[1]},
             },
             "destination": (
                 {"place_name": "", "address": "",
-                 "coordinate": {"lat": st.session_state.end[0], "lon": st.session_state.end[1]}}
+                "coordinate": {"lat": st.session_state.end[0], "lon": st.session_state.end[1]}}
                 if st.session_state.end else None
             ),
             "purpose": "산책",
         }
+
 
     def _save(self, result: dict) -> None:
         """
@@ -93,18 +65,15 @@ class WalkRouteButton:
                     st.error("편도 모드에서는 도착지를 설정해야 합니다!")
                 else:
                     with st.spinner("최적의 경로를 계산하는 중..."):
-                        context = self._build_context(selected_mode, distance_km, lat, lng)
-                        result = (
-                            _get_child_route(context, self.G)
-                            if child_friendly
-                            else self._route_service.get_route(context, G_full=self.G)
-                        )
-                        if result.get("error"):
-                            st.error(f"오류 발생: {result['error']}")
-                        else:
-                            self._save(result)
-                            st.rerun()
-
+                        context = self._build_context(selected_mode, distance_km, child_friendly, lat, lng)
+                        result  = self._call_api(context)
+                    if "coordinates" not in result:
+                        st.error(f"API 오류: {result.get('detail') or result.get('error')}")
+                    elif result.get("error"):
+                        st.error(f"오류 발생: {result['error']}")
+                    else:
+                        self._save(result)
+                        st.rerun()
         elif input_mode == "AI 챗봇":
             state = st.session_state.get("state", {})
             if state and state.get("next_node") == "end" and not st.session_state.route_coordinates:
@@ -113,7 +82,9 @@ class WalkRouteButton:
                 destination = user_context.get("destination")
                 with st.spinner("최적의 경로를 계산하는 중..."):
                     context = {
-                        "mode": selected_mode, "distance_km": distance_km,
+                        "mode": selected_mode, 
+                        "distance_km": distance_km,
+                        "child_friendly": False,
                         "origin": {
                             "place_name": origin.get("place_name", ""), "address": origin.get("address", ""),
                             "coordinate": {"lat": origin.get("lat", lat), "lon": origin.get("lon", lng)},
@@ -125,8 +96,10 @@ class WalkRouteButton:
                         ),
                         "purpose": user_context.get("purpose", "산책"),
                     }
-                    result = self._route_service.get_route(context, G_full=self.G)
-                    if result.get("error"):
+                    result = self._call_api(context)
+                    if "coordinates" not in result:
+                        st.error(f"API 오류: {result.get('detail') or result.get('error')}")
+                    elif result.get("error"):
                         st.error(f"오류 발생: {result['error']}")
                     else:
                         self._save(result)

--- a/src/interfaces/api/walk_router.py
+++ b/src/interfaces/api/walk_router.py
@@ -22,10 +22,10 @@ async def walk_route(request: WalkRouteRequest):
         start_lat   = request.origin.coordinate.lat
         start_lon   = request.origin.coordinate.lon
         distance_km = request.distance_km
-
         if request.child_friendly:
             radius_m = distance_km * 1000 * 3.0
-            G = GraphRepository.load_graph_near(start_lat, start_lon, radius_m=radius_m)
+            G_raw    = GraphRepository.load_graph_near(start_lat, start_lon, radius_m=radius_m)
+            G        = RouteService().extract_subgraph_near(G_raw, start_lat, start_lon, radius_m)
 
             if request.mode == "circular":
                 inp    = CircularRouteInput(start_lat=start_lat, start_lon=start_lon, target_km=distance_km)
@@ -50,7 +50,9 @@ async def walk_route(request: WalkRouteRequest):
             )
 
         else:
-            context = {
+            radius_m = distance_km * 1000 * 3.0
+            G_full   = GraphRepository.load_graph_near(start_lat, start_lon, radius_m=radius_m)
+            context  = {
                 "mode":         request.mode,
                 "distance_km":  distance_km,
                 "origin": {
@@ -71,7 +73,7 @@ async def walk_route(request: WalkRouteRequest):
                 ),
                 "purpose": request.purpose,
             }
-            return RouteService().get_route(context)
+            return RouteService().get_route(context, G_full=G_full)
 
     except HTTPException:
         raise

--- a/src/interfaces/api/walk_router.py
+++ b/src/interfaces/api/walk_router.py
@@ -1,0 +1,80 @@
+import traceback
+
+from fastapi import APIRouter, HTTPException
+
+from src.interfaces.schema.walk_schema import WalkRouteRequest, WalkRouteResponse
+from src.service.route.route_service import RouteService
+from src.route_engine.engines.circular.child import CircularChildEngine
+from src.route_engine.engines.oneway.child import OnewayChildEngine
+from src.route_engine.schema import CircularRouteInput, OnewayRouteInput
+from src.repository.network.graph_repository import GraphRepository
+
+router = APIRouter(
+    prefix="/api/walk",
+    tags=["walk"],
+)
+
+
+@router.post("/route", response_model=WalkRouteResponse)
+async def walk_route(request: WalkRouteRequest):
+    """출발지 기반 산책 경로를 추천합니다."""
+    try:
+        start_lat   = request.origin.coordinate.lat
+        start_lon   = request.origin.coordinate.lon
+        distance_km = request.distance_km
+
+        if request.child_friendly:
+            radius_m = distance_km * 1000 * 3.0
+            G = GraphRepository.load_graph_near(start_lat, start_lon, radius_m=radius_m)
+
+            if request.mode == "circular":
+                inp    = CircularRouteInput(start_lat=start_lat, start_lon=start_lon, target_km=distance_km)
+                engine = CircularChildEngine(inp, G)
+            else:
+                if not request.destination:
+                    raise HTTPException(status_code=400, detail="편도 모드에서는 목적지가 필요합니다")
+                inp = OnewayRouteInput(
+                    start_lat=start_lat, start_lon=start_lon,
+                    end_lat=request.destination.coordinate.lat,
+                    end_lon=request.destination.coordinate.lon,
+                    target_km=distance_km,
+                )
+                engine = OnewayChildEngine(inp, G, use_random=(request.mode == "oneway_random"))
+
+            output = engine.run()
+            return WalkRouteResponse(
+                mode=output.mode,
+                coordinates=output.coordinates,
+                total_distance_km=output.total_km,
+                error=output.fallback_reason.value if output.fallback_reason else None,
+            )
+
+        else:
+            context = {
+                "mode":         request.mode,
+                "distance_km":  distance_km,
+                "origin": {
+                    "place_name": request.origin.place_name,
+                    "address":    request.origin.address,
+                    "coordinate": {"lat": start_lat, "lon": start_lon},
+                },
+                "destination": (
+                    {
+                        "place_name": request.destination.place_name,
+                        "address":    request.destination.address,
+                        "coordinate": {
+                            "lat": request.destination.coordinate.lat,
+                            "lon": request.destination.coordinate.lon,
+                        },
+                    }
+                    if request.destination else None
+                ),
+                "purpose": request.purpose,
+            }
+            return RouteService().get_route(context)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/interfaces/schema/walk_schema.py
+++ b/src/interfaces/schema/walk_schema.py
@@ -1,0 +1,29 @@
+from typing import Optional, List
+from pydantic import BaseModel, Field
+
+
+class Coordinate(BaseModel):
+    lat: float
+    lon: float
+
+
+class LocationInfo(BaseModel):
+    place_name: str = ""
+    address: str = ""
+    coordinate: Coordinate
+
+
+class WalkRouteRequest(BaseModel):
+    mode: str = Field(..., description="circular | oneway_shortest | oneway_random")
+    distance_km: float = Field(3.0, ge=1.0, le=20.0)
+    child_friendly: bool = Field(False)
+    origin: LocationInfo
+    destination: Optional[LocationInfo] = None
+    purpose: str = Field("산책")
+
+
+class WalkRouteResponse(BaseModel):
+    mode: str
+    coordinates: List[List[float]]
+    total_distance_km: float
+    error: Optional[str] = None

--- a/src/main.py
+++ b/src/main.py
@@ -10,8 +10,10 @@ from src.interfaces.api import (
     prewalk_router,
     user_router,
     weather_router,
-    running_router
+    running_router,
+    walk_router,
 )
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -42,6 +44,7 @@ app.include_router(prewalk_router.router)
 app.include_router(auth_router.router)
 app.include_router(login_router.router)
 app.include_router(running_router.router)
+app.include_router(walk_router.router)
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
## ☝️Issue Number
- resolve #125 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- POST /api/walk/route 신규 엔드포인트 생성 및 프론트엔드 HTTP 클라이언트 연결
- 기존 walk_route_button.py의 src/ 직접 의존성(RouteService, child 엔진)을 API 클라이언트 호출로 교체
- child_friendly 경로 처리 및 그래프 필터링(lat/lon 없는 노드 제거) 포함
