### PR TITLE
[Feat] GET /api/health 신규 엔드포인트 및 프론트 연결

### DIFF
--- a/frontend/streamlit_prototype/api/health_router.py
+++ b/frontend/streamlit_prototype/api/health_router.py
@@ -1,0 +1,27 @@
+"""
+frontend/streamlit_prototype/api/health_router.py
+
+GET /api/health HTTP 클라이언트 래퍼
+FastAPI 서버의 DB 연결 상태 확인 엔드포인트를 동기 방식으로 호출
+"""
+import httpx
+from frontend.streamlit_prototype.api.base_url import base_url
+
+
+class HealthRouter:
+    def __init__(self):
+        self.base_url = f"{base_url}/api/health"
+
+    def get_health(self) -> bool:
+        """
+        input : 없음
+        output: bool (DB 연결 정상이면 True, 실패 또는 서버 오류 시 False)
+
+        GET /api/health를 동기 호출해 ok 필드를 반환
+        요청 실패 시 False 반환
+        """
+        try:
+            response = httpx.get(self.base_url, timeout=3.0)
+            return response.json().get("ok", False)
+        except Exception:
+            return False

--- a/frontend/streamlit_prototype/components/sidebar/route_sidebar.py
+++ b/frontend/streamlit_prototype/components/sidebar/route_sidebar.py
@@ -1,6 +1,6 @@
 import streamlit as st
 
-from src.database.postgresql import health_check
+from frontend.streamlit_prototype.api.health_router import HealthRouter
 from src.route_engine.engines.route_flat import get_flat_mode_options
 
 
@@ -10,7 +10,7 @@ class RouteSidebar:
         """
         DB 상태, 입력 방식, 경로 모드·거리·가중치 슬라이더를 렌더링하고 설정값 딕셔너리를 반환합니다.
         """
-        db_ok = health_check()
+        db_ok = HealthRouter().get_health()
         st.sidebar.markdown("### 시스템 상태")
         st.sidebar.success("🟢 DB 연결됨") if db_ok else st.sidebar.error("🔴 DB 연결 실패")
 

--- a/frontend/streamlit_prototype/components/sidebar/walk_sidebar.py
+++ b/frontend/streamlit_prototype/components/sidebar/walk_sidebar.py
@@ -1,7 +1,6 @@
 import streamlit as st
 
-from src.database.postgresql import health_check
-
+from frontend.streamlit_prototype.api.health_router import HealthRouter
 
 class WalkSidebar:
 
@@ -9,7 +8,7 @@ class WalkSidebar:
         """
         DB 상태, 입력 방식, 경로 모드, 가중치 슬라이더, 아이 동반 옵션을 렌더링하고 설정값 딕셔너리를 반환합니다.
         """
-        db_ok = health_check()
+        db_ok = HealthRouter().get_health()
         st.sidebar.markdown("### 시스템 상태")
         st.sidebar.success("🟢 DB 연결됨") if db_ok else st.sidebar.error("🔴 DB 연결 실패")
 

--- a/frontend/streamlit_prototype/sections/sidebar.py
+++ b/frontend/streamlit_prototype/sections/sidebar.py
@@ -8,7 +8,7 @@ DB 연결 상태 표시, 입력 방식(직접 설정 / AI 챗봇) 선택, 선택
 import streamlit as st
 from dataclasses import dataclass
 
-from src.database.postgresql import health_check
+from frontend.streamlit_prototype.api.health_router import HealthRouter
 from frontend.streamlit_prototype.modes.base import BaseRouteMode, RouteParams
 from frontend.streamlit_prototype.modes.registry import ROUTE_MODES
 
@@ -50,7 +50,7 @@ def render_sidebar() -> SidebarConfig:
 
     DB 연결 상태, 입력 방식, 모드 선택, 파라미터 입력 UI를 렌더링
     """
-    db_ok = health_check()
+    db_ok = HealthRouter().get_health()
     st.sidebar.markdown("### 시스템 상태")
     st.sidebar.success("🟢 DB 연결됨") if db_ok else st.sidebar.error("🔴 DB 연결 실패")
     st.sidebar.markdown("### 경로 설정")

--- a/src/interfaces/api/health_router.py
+++ b/src/interfaces/api/health_router.py
@@ -1,0 +1,21 @@
+"""
+src/interfaces/api/health_router.py
+
+GET /api/health 엔드포인트 정의
+DB 연결 상태를 확인하고 결과를 반환
+"""
+from fastapi import APIRouter
+from src.database.postgresql import health_check
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/api/health")
+def get_health():
+    """
+    input : 없음
+    output: {"ok": bool}
+
+    DB 연결 상태를 확인해 ok 필드로 반환
+    """
+    return {"ok": health_check()}

--- a/src/main.py
+++ b/src/main.py
@@ -12,8 +12,8 @@ from src.interfaces.api import (
     weather_router,
     running_router,
     walk_router,
+    health_router,
 )
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -45,6 +45,7 @@ app.include_router(auth_router.router)
 app.include_router(login_router.router)
 app.include_router(running_router.router)
 app.include_router(walk_router.router)
+app.include_router(health_router.router)
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
## ☝️Issue Number
- resolve #132 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- GET /api/health 신규 엔드포인트 생성 및 프론트엔드 HTTP 클라이언트 연결
- 기존 sidebar.py, route_sidebar.py, walk_sidebar.py의 src/ 직접 의존성(health_check())을 API 클라이언트 호출로 교체
