### PR TITLE
[Feat] GET /api/map/layers 신규 엔드포인트 및 프론트 연결

### DIFF
--- a/frontend/streamlit_prototype/api/map_router.py
+++ b/frontend/streamlit_prototype/api/map_router.py
@@ -1,0 +1,63 @@
+"""
+frontend/streamlit_prototype/api/map_router.py
+
+지도 레이어 데이터 HTTP 클라이언트 래퍼
+카카오 시설, DB 포인트, DB 엣지 3가지 엔드포인트를 동기 방식으로 호출
+"""
+import httpx
+from frontend.streamlit_prototype.api.base_url import base_url
+
+
+class MapRouter:
+    def __init__(self):
+        self.base_url = f"{base_url}/api/map"
+
+    def get_facilities(self, lat, lon, category_code=None, keyword=None, radius=2000) -> list:
+        """
+        input : lat, lon, category_code, keyword, radius
+        output: [{"name", "lon", "lat", "address"}, ...] 또는 실패 시 []
+
+        GET /api/map/facilities 호출
+        """
+        try:
+            params = {"lat": lat, "lon": lon, "radius": radius}
+            if category_code:
+                params["category_code"] = category_code
+            if keyword:
+                params["keyword"] = keyword
+            return httpx.get(f"{self.base_url}/facilities", params=params, timeout=10.0).json()
+        except Exception:
+            return []
+
+    def get_points(self, lat, lon, table_name, type_col=None, type_val=None, radius_m=2000) -> list:
+        """
+        input : lat, lon, table_name, type_col, type_val, radius_m
+        output: [{"lat", "lon"}, ...] 또는 실패 시 []
+
+        GET /api/map/points 호출
+        """
+        try:
+            params = {"lat": lat, "lon": lon, "table_name": table_name, "radius_m": radius_m}
+            if type_col:
+                params["type_col"] = type_col
+            if type_val:
+                params["type_val"] = type_val
+            return httpx.get(f"{self.base_url}/points", params=params, timeout=10.0).json()
+        except Exception:
+            return []
+
+    def get_edges(self, lat, lon, radius_m=2000) -> list:
+        """
+        input : lat, lon, radius_m
+        output: [{"path": [[lon, lat], ...], "link_id": str}, ...] 또는 실패 시 []
+
+        GET /api/map/edges 호출
+        """
+        try:
+            return httpx.get(
+                f"{self.base_url}/edges",
+                params={"lat": lat, "lon": lon, "radius_m": radius_m},
+                timeout=10.0,
+            ).json()
+        except Exception:
+            return []

--- a/frontend/streamlit_prototype/components/layer/map_layer.py
+++ b/frontend/streamlit_prototype/components/layer/map_layer.py
@@ -1,21 +1,22 @@
-import json
+"""
+frontend/streamlit_prototype/components/layer/map_layer.py
 
+지도 레이어 데이터를 API를 통해 조회하고 DataFrame으로 변환하는 컴포넌트
+카카오 시설, DB 포인트, DB 엣지 3가지 레이어를 제공
+"""
 import pandas as pd
 import streamlit as st
 
-from src.infrastructure.external.client.kakao_client import KakaoClient
-from src.service.route.map_service import MapService
-from src.repository.layer.map_repository import MapRepository
-from src.repository.network.edge_repository import EdgeRepository
+from frontend.streamlit_prototype.api.map_router import MapRouter
 
 
 class MapLayer:
 
     def __init__(self):
-        self._map_service = MapService(KakaoClient())
+        self._router = MapRouter()
 
     @st.cache_data(ttl=3600)
-    async def fetch_kakao_facilities_df(
+    def fetch_kakao_facilities_df(
         _self,
         lat: float,
         lon: float,
@@ -23,15 +24,14 @@ class MapLayer:
         keyword: str | None = None,
         radius: int = 2000,
     ) -> pd.DataFrame:
-        all_places = await _self._map_service.fetch_kakao_facilities(
-            lat, lon, category_code=category_code, keyword=keyword, radius=radius
-        )
-        if not all_places:
-            return pd.DataFrame()
-        return pd.DataFrame([
-            {"name": p["place_name"], "lon": float(p["x"]), "lat": float(p["y"]), "address": p["address_name"]}
-            for p in all_places
-        ])
+        """
+        input : lat, lon, category_code, keyword, radius
+        output: DataFrame (name, lon, lat, address)
+
+        GET /api/map/facilities 호출 후 DataFrame으로 변환
+        """
+        data = _self._router.get_facilities(lat, lon, category_code=category_code, keyword=keyword, radius=radius)
+        return pd.DataFrame(data) if data else pd.DataFrame()
 
     @st.cache_data(ttl=3600)
     def fetch_local_db_points(
@@ -43,7 +43,14 @@ class MapLayer:
         type_val: str | None = None,
         radius_m: int = 2000,
     ) -> pd.DataFrame:
-        return MapRepository.fetch_nearby_points(lat, lon, table_name, type_col, type_val, radius_m)
+        """
+        input : lat, lon, table_name, type_col, type_val, radius_m
+        output: DataFrame (lat, lon)
+
+        GET /api/map/points 호출 후 DataFrame으로 변환
+        """
+        data = _self._router.get_points(lat, lon, table_name, type_col, type_val, radius_m)
+        return pd.DataFrame(data) if data else pd.DataFrame()
 
     @st.cache_data(ttl=3600)
     def fetch_local_db_lines_optimized(
@@ -52,8 +59,12 @@ class MapLayer:
         lon: float,
         radius_m: int = 2000,
     ) -> pd.DataFrame:
-        df = EdgeRepository.fetch_nearby_lines(lat, lon, radius_m)
-        if df.empty:
-            return pd.DataFrame()
-        df["path"] = df["geometry"].apply(lambda x: json.loads(x)["coordinates"])
-        return df[["path", "link_id"]]
+        """
+        input : lat, lon, radius_m
+        output: DataFrame (path, link_id)
+
+        GET /api/map/edges 호출 후 DataFrame으로 변환
+        GeoJSON 파싱은 서버에서 처리해 path([[lon, lat], ...])로 반환됨
+        """
+        data = _self._router.get_edges(lat, lon, radius_m)
+        return pd.DataFrame(data) if data else pd.DataFrame()

--- a/src/interfaces/api/map_router.py
+++ b/src/interfaces/api/map_router.py
@@ -1,0 +1,99 @@
+"""
+src/interfaces/api/map_router.py
+
+지도 레이어 데이터 조회 엔드포인트 정의
+카카오 시설(외부 API), DB 포인트, DB 엣지 3가지 데이터 소스를 각각 제공
+"""
+import json
+import traceback
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+
+from src.infrastructure.external.client.kakao_client import KakaoClient
+from src.service.route.map_service import MapService
+
+router = APIRouter(
+    prefix="/api/map",
+    tags=["map"],
+)
+
+
+def _get_map_service() -> MapService:
+    return MapService(KakaoClient())
+
+
+@router.get("/facilities")
+async def get_facilities(
+    lat: float,
+    lon: float,
+    category_code: Optional[str] = None,
+    keyword: Optional[str] = None,
+    radius: int = 2000,
+):
+    """
+    input : lat, lon, category_code, keyword, radius
+    output: [{"name", "lon", "lat", "address"}, ...]
+
+    카카오 장소 API로 시설 목록을 조회해 반환
+    """
+    try:
+        places = await _get_map_service().fetch_kakao_facilities(
+            lat, lon, category_code=category_code, keyword=keyword, radius=radius
+        )
+        return [
+            {"name": p.place_name, "lon": float(p.x), "lat": float(p.y), "address": p.address_name}
+            for p in places
+        ]
+    except Exception as e:
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/points")
+def get_points(
+    lat: float,
+    lon: float,
+    table_name: str,
+    type_col: Optional[str] = None,
+    type_val: Optional[str] = None,
+    radius_m: int = 2000,
+):
+    """
+    input : lat, lon, table_name, type_col, type_val, radius_m
+    output: [{"lat", "lon"}, ...]
+
+    DB에서 반경 내 포인트 레이어 데이터를 조회해 반환
+    지원하지 않는 table_name 입력 시 400 반환
+    """
+    try:
+        df = _get_map_service().fetch_db_points(lat, lon, table_name, type_col, type_val, radius_m)
+        return df.to_dict(orient="records")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/edges")
+def get_edges(
+    lat: float,
+    lon: float,
+    radius_m: int = 2000,
+):
+    """
+    input : lat, lon, radius_m
+    output: [{"path": [[lon, lat], ...], "link_id": str}, ...]
+
+    DB에서 반경 내 도보 네트워크 엣지를 조회하고 GeoJSON geometry를 좌표 배열로 변환해 반환
+    """
+    try:
+        df = _get_map_service().fetch_db_lines(lat, lon, radius_m)
+        if df.empty:
+            return []
+        df["path"] = df["geometry"].apply(lambda x: json.loads(x)["coordinates"])
+        return df[["path", "link_id"]].to_dict(orient="records")
+    except Exception as e:
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ from src.interfaces.api import (
     running_router,
     walk_router,
     health_router,
+    map_router,
 )
 
 @asynccontextmanager
@@ -46,6 +47,7 @@ app.include_router(login_router.router)
 app.include_router(running_router.router)
 app.include_router(walk_router.router)
 app.include_router(health_router.router)
+app.include_router(map_router.router)
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
## ☝️Issue Number
- resolve #134 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- GET /api/map/facilities, /api/map/points, /api/map/edges 신규 엔드포인트 생성 및 프론트엔드 HTTP 클라이언트 연결
- 기존 map_layer.py의 src/ 직접 의존성(KakaoClient, MapService, MapRepository, EdgeRepository)을 API 클라이언트 호출로 교체
