### PR TITLE
[Feat] GET /api/banner 신규 엔드포인트 및 프론트 연결

### DIFF
--- a/frontend/streamlit_prototype/api/banner_router.py
+++ b/frontend/streamlit_prototype/api/banner_router.py
@@ -1,0 +1,28 @@
+"""
+frontend/streamlit_prototype/api/banner_router.py
+
+GET /api/banner HTTP 클라이언트 래퍼
+날씨 상태와 시각을 전달해 배너 목록을 동기 방식으로 조회
+"""
+import httpx
+from frontend.streamlit_prototype.api.base_url import base_url
+
+
+class BannerRouter:
+    def __init__(self):
+        self.base_url = f"{base_url}/api/banner"
+
+    def get_banner_list(self, weather_status: str, weather_msg: str, hour: int | None = None) -> list:
+        """
+        input : weather_status, weather_msg, hour (선택)
+        output: [{"emoji", "text", "sub", ...}, ...] 또는 실패 시 []
+
+        GET /api/banner 호출 후 배너 목록 반환
+        """
+        try:
+            params = {"weather_status": weather_status, "weather_msg": weather_msg}
+            if hour is not None:
+                params["hour"] = hour
+            return httpx.get(self.base_url, params=params, timeout=10.0).json()
+        except Exception:
+            return []

--- a/frontend/streamlit_prototype/components/carousel/banner_data_carousel.py
+++ b/frontend/streamlit_prototype/components/carousel/banner_data_carousel.py
@@ -1,42 +1,44 @@
+"""
+frontend/streamlit_prototype/components/carousel/banner_data_carousel.py
+
+배너 목록을 API를 통해 조회하고 렌더링하는 캐러셀 컴포넌트
+날씨 상태와 현재 시각을 기반으로 배너 목록을 구성
+"""
 from datetime import datetime
 
 import streamlit as st
 
-from src.infrastructure.external.client.marathon_client import MarathonClient
-from src.service.route.banner_service import BannerService
+from frontend.streamlit_prototype.api.banner_router import BannerRouter
 
 
 class BannerDataCarousel:
 
     def __init__(self):
-        self._service = BannerService(MarathonClient())
+        self._router = BannerRouter()
 
     @st.cache_data(ttl=3600)
-    def get_events_cached(_self) -> list[dict]:
-        return _self._service.get_events()
+    def get_events_cached(_self) -> list:
+        """
+        input : 없음
+        output: list (마라톤 이벤트 목록)
+
+        GET /api/banner를 통해 이벤트 포함 배너 목록을 캐싱해 반환
+        """
+        return _self._router.get_banner_list("", "")
 
     def get_banner_list(self, weather: dict, hour: int | None = None) -> list:
+        """
+        input : weather (weather_status, weather_msg 포함 dict), hour (선택)
+        output: [{"emoji", "text", "sub", ...}, ...]
+
+        GET /api/banner 호출 후 배너 목록 반환
+        hour 미입력 시 현재 시각 사용
+        """
         if hour is None:
             hour = datetime.now().hour
 
-        status = weather.get("weather_status", "")
-        msg    = weather.get("weather_msg", "")
-        banners = []
-
-        active_event = self._service.get_active_event()
-        if active_event:
-            banners.append(self._service._get_event_text(active_event))
-
-        if self._service._is_hot(msg):
-            if 6 <= hour < 9:
-                banners.append(self._service.BANNERS["season"]["hot_morning"])
-            elif self._service._is_humid(status):
-                banners.append(self._service.BANNERS["season"]["hot_humid"])
-            else:
-                banners.append(self._service.BANNERS["season"]["hot_sunny"])
-
-        keys = ["dog", "healing"] if hour < 17 else (["dog", "healing", "night"] if hour < 21 else ["night"])
-        for key in keys:
-            banners.append(self._service.BANNERS["fixed"][key])
-
-        return banners
+        return self._router.get_banner_list(
+            weather_status=weather.get("weather_status", ""),
+            weather_msg=weather.get("weather_msg", ""),
+            hour=hour,
+        )

--- a/src/interfaces/api/banner_router.py
+++ b/src/interfaces/api/banner_router.py
@@ -1,0 +1,78 @@
+"""
+src/interfaces/api/banner_router.py
+
+GET /api/banner 엔드포인트 정의
+날씨 상태와 현재 시각을 기반으로 배너 목록을 반환
+마라톤 이벤트(외부 API) → 시즌 배너 → 고정 배너 순으로 구성
+"""
+from datetime import datetime, date
+import traceback
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+
+from src.infrastructure.external.client.marathon_client import MarathonClient
+from src.infrastructure.external.schema.weather_schema import EnvironmentInfo
+from src.service.route.banner_service import BannerService
+
+router = APIRouter(tags=["banner"])
+
+
+@router.get("/api/banner")
+async def get_banner(
+    weather_status: str = "",
+    weather_msg: str = "",
+    hour: Optional[int] = None,
+):
+    """
+    input : weather_status, weather_msg, hour (선택)
+    output: [{"emoji", "text", "sub", ...}, ...]
+
+    BannerService의 asyncio.run() 충돌을 피하기 위해
+    _fetch_all_events()를 직접 await해서 배너 목록 구성
+    """
+    try:
+        service = BannerService(MarathonClient())
+        weather = EnvironmentInfo(
+            weather_status=weather_status,
+            weather_msg=weather_msg,
+            air_status="", air_msg="", display_msg="",
+        )
+
+        if hour is None:
+            hour = datetime.now().hour
+
+        banners = []
+
+        # 이벤트 배너
+        today  = date.today()
+        events = await service._fetch_all_events()
+        for event in events:
+            diff = (event.date - today).days
+            if -1 <= diff <= 14:
+                banners.append(service._get_event_text({**event.model_dump(), "diff": diff}))
+                break
+
+        # 시즌 배너
+        if service._is_hot(weather.weather_msg):
+            if 6 <= hour < 9:
+                banners.append(service.BANNERS["season"]["hot_morning"])
+            elif service._is_humid(weather.weather_status):
+                banners.append(service.BANNERS["season"]["hot_humid"])
+            else:
+                banners.append(service.BANNERS["season"]["hot_sunny"])
+
+        # 고정 배너
+        keys = (
+            ["dog", "healing"] if hour < 17
+            else ["dog", "healing", "night"] if hour < 21
+            else ["night"]
+        )
+        for key in keys:
+            banners.append(service.BANNERS["fixed"][key])
+
+        return banners
+
+    except Exception as e:
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ from src.interfaces.api import (
     walk_router,
     health_router,
     map_router,
+    banner_router,
 )
 
 @asynccontextmanager
@@ -48,6 +49,7 @@ app.include_router(running_router.router)
 app.include_router(walk_router.router)
 app.include_router(health_router.router)
 app.include_router(map_router.router)
+app.include_router(banner_router.router)
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
## ☝️Issue Number
- resolve #137 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- GET /api/banner 신규 엔드포인트 생성 및 프론트엔드 HTTP 클라이언트 연결
- 기존 banner_data_carousel.py의 src/ 직접 의존성(MarathonClient, BannerService)을 API 클라이언트 호출로 교체
- FastAPI async 컨텍스트 내 asyncio.run() 충돌 해결을 위해 _fetch_all_events()를 직접 await 처리
