### PR TITLE
[Feat] 챗봇 NLU 브릿지 profile_name 연결

### DIFF
--- a/frontend/streamlit_prototype/components/button/walk_route_button.py
+++ b/frontend/streamlit_prototype/components/button/walk_route_button.py
@@ -23,6 +23,7 @@ class WalkRouteButton:
             "mode":           selected_mode,
             "distance_km":    distance_km,
             "child_friendly": child_friendly,
+            "profile_name":   "child" if child_friendly else "default",
             "origin": {
                 "place_name": "", "address": "",
                 "coordinate": {"lat": st.session_state.start[0], "lon": st.session_state.start[1]},
@@ -80,11 +81,19 @@ class WalkRouteButton:
                 user_context = state.get("user_context", {})
                 origin      = user_context.get("origin", {})
                 destination = user_context.get("destination")
+                
+                # LLM 추출값(profile_name, child_friendly)을 route API payload로 안전하게 전달하기 위한 보정
+                # API 파손을 막기 위해 추출값을 소문자로 정규화
+                profile_name = str(user_context.get("profile_name", "default")).lower().strip()
+                # profile_name == "child"일 경우 API가 올바른 엔진으로 분기할 수 있도록 child_friendly 플래그 동기화
+                is_child_friendly = user_context.get("child_friendly", False) or (profile_name == "child")
+
                 with st.spinner("최적의 경로를 계산하는 중..."):
                     context = {
                         "mode": selected_mode, 
                         "distance_km": distance_km,
-                        "child_friendly": False,
+                        "child_friendly": is_child_friendly,
+                        "profile_name": profile_name,
                         "origin": {
                             "place_name": origin.get("place_name", ""), "address": origin.get("address", ""),
                             "coordinate": {"lat": origin.get("lat", lat), "lon": origin.get("lon", lng)},

--- a/frontend/streamlit_prototype/components/panel/chat_panel.py
+++ b/frontend/streamlit_prototype/components/panel/chat_panel.py
@@ -103,7 +103,7 @@ class ChatPanel:
                 st.json({"state": state, "weights": weights_data})
             user_context = state.get("user_context", {})
             if user_context:
-                mode_map = {"Circular": "circular", "Destination": "oneway_shortest", "Distance": "oneway_random"}
+                mode_map = {"Circular": "circular", "Destination": "oneway_shortest", "Distance": "circular"}
                 return (
                     weights_data.get("safety", safety_w),
                     weights_data.get("nature", nature_w),

--- a/src/interfaces/api/walk_router.py
+++ b/src/interfaces/api/walk_router.py
@@ -22,7 +22,12 @@ async def walk_route(request: WalkRouteRequest):
         start_lat   = request.origin.coordinate.lat
         start_lon   = request.origin.coordinate.lon
         distance_km = request.distance_km
-        if request.child_friendly:
+        
+        # profile_name을 한 번만 정규화하여 하위 분기 및 엔진 호출 시 일관되게 사용
+        profile_name = request.profile_name.lower().strip() if request.profile_name else "default"
+        
+        # child_friendly 플래그나 profile_name이 child일 경우 모두 child 전용 엔진으로 라우팅
+        if request.child_friendly or profile_name == "child":
             radius_m = distance_km * 1000 * 3.0
             G_raw    = GraphRepository.load_graph_near(start_lat, start_lon, radius_m=radius_m)
             G        = RouteService().extract_subgraph_near(G_raw, start_lat, start_lon, radius_m)
@@ -73,7 +78,8 @@ async def walk_route(request: WalkRouteRequest):
                 ),
                 "purpose": request.purpose,
             }
-            return RouteService().get_route(context, G_full=G_full)
+            # API 요청의 정규화된 profile_name을 RouteService의 profile layer까지 명시적으로 전달
+            return RouteService().get_route(context, G_full=G_full, profile_name=profile_name)
 
     except HTTPException:
         raise

--- a/src/interfaces/schema/walk_schema.py
+++ b/src/interfaces/schema/walk_schema.py
@@ -21,6 +21,10 @@ class WalkRouteRequest(BaseModel):
     destination: Optional[LocationInfo] = None
     purpose: str = Field("산책")
 
+    # 챗봇/프론트에서 추출한 사용자 선호를 route_engine profile로 전달하기 위한 값
+    # (참고: 그늘/시원함 등 전용 프로필이 없는 항목은 프롬프트 단에서 'quiet'으로 임시 매핑됨)
+    profile_name: str = Field("default", description="지원 프로필: default, quiet, flat, safe, scenic, child, running")
+
 
 class WalkRouteResponse(BaseModel):
     mode: str

--- a/src/prompt/extraction.yaml
+++ b/src/prompt/extraction.yaml
@@ -26,13 +26,33 @@ template: |
   - **purpose (목적)**: 
     - [User Input]과 [Current Context]를 결합하여 사용자의 산책 의도(예: 강아지 산책, 식후 소화, 러닝 등)를 구체적으로 서술.
 
-  ### 3. 데이터 참조 (Context)
+  ### 3. 프로필(Profile) 및 부가 정보 추출 규칙
+  - 주의: DB 컬럼명(예: shade_score, scenery_score 등)을 임의로 만들지 마세요. 
+  - 프로필 관련 추가 출력 필드는 `profile_name`, `child_friendly`, `unsupported_preferences` 뿐입니다.
+  - **profile_name**: 사용자의 문장을 분석하여 다음 중 단 **하나**만 선택하세요. (현재 산책 챗봇 모드 전용)
+    - child: 아이, 어린이, 가족, 애 데리고, 유모차 (이 경우 child_friendly=true 함께 설정)
+    - flat: 평지, 오르막 싫음, 경사 싫음, 무릎/다리 부담
+    - safe: 안전, 밤길, 무서움, 밝은 길, 큰길, CCTV
+    - quiet: 조용함, 한적함, 사람 적음, 더움, 시원한 길, 그늘 (※더위/그늘/시원함은 전용 프로필이 없으므로 가장 유사한 quiet으로 임시 매핑)
+    - scenic: 예쁜 길, 풍경, 기분 전환, 우울함, 랜드마크
+    - default: 판단 어려움
+    ※ TODO: 러닝(running)은 현재 API에서 러닝 전용 엔진 라우팅이 불안정하므로 사용하지 않습니다. 사용자가 뛰겠다고 해도 default나 flat 등으로 우회 매핑하세요.
+  - **unsupported_preferences**: "더위", "그늘" 처럼 현재 지원하지 않는 요구사항을 quiet 등에 임시 매핑했을 때, 사용자의 원래 요구 단어를 이 리스트에 남기세요.
+
+  ### 4. 불친절한 입력(정보 부족) 처리 규칙
+  정보가 부족하면 억지로 값을 채우지 말고 null이나 default를 유지하세요. (이후 interview 흐름에서 알아서 되묻게 됩니다)
+  - "그냥 산책" -> profile_name: default, distance_km: 1.0
+  - "강남역 갈래" -> profile_name: default, destination: 강남역 (origin 누락 상태 유지)
+  - "다리 아파" -> profile_name: flat (거리 등 나머지 기본값)
+  - "밤에 무서워" -> profile_name: safe
+
+  ### 5. 데이터 참조 (Context)
   [Current Location]: {current_location}
   [Current Context]: {current_context}
   [Origin Candidates]: {origin_candidates}
   [Destination Candidates]: {destination_candidates}
 
-  ### 4. 사용자 입력
+  ### 6. 사용자 입력
   [User Input]: {user_input}
 
   위 규칙을 바탕으로 지정된 스키마 형식에 맞춰 데이터를 추출하세요.

--- a/src/schema/prewalk_schema.py
+++ b/src/schema/prewalk_schema.py
@@ -19,6 +19,20 @@ class BasePreference(BaseModel):
     """
     origin: Optional[Location] = Field(None, description="출발지 정보")
     purpose: Optional[str] = Field(None, description="산책 목적")
+    
+    # 챗봇에서 추출한 사용자 선호를 route_engine.profiles.py와 연결하기 위한 필드
+    profile_name: str = Field(
+        "default", 
+        description="route_engine.profiles.py와 매핑되는 프로필명 (default, quiet, flat, safe, scenic, child, running)"
+    )
+    child_friendly: bool = Field(False, description="어린이 동반, 유모차 등 안전 우선 모드 여부")
+    
+    # 현재 시스템(route_engine/DB)에서 직접 지원하지 않는 조건(예: 그늘, 시원함)을 
+    # 유실하지 않고 기록하기 위한 보존용 필드
+    unsupported_preferences: list[str] = Field(
+        default_factory=list, 
+        description="현재 매핑 불가능한 사용자 요구사항 보존"
+    )
 
 
 class CircularPreference(BasePreference):


### PR DESCRIPTION
## ☝️Issue Number
- resolve #116 

## 변경 사항 및 목적
AI 챗봇이 분석한 사용자 선호도가 `route_engine`의 profile layer까지 유실 없이 전달되도록 NLU 브릿지 파이프라인을 연결했습니다.

기존 에이전트 내부 출력 구조(`WalkPreferenceExtraction`)는 유지하고, 통합테스트 안정성을 위해 필요한 필드와 payload 전달 경로만 최소 범위로 확장했습니다.

## 주요 변경 사항
1. 스키마 확장
- `src/schema/prewalk_schema.py`
  - 챗봇 내부 상태에 `profile_name`, `child_friendly`, `unsupported_preferences` 추가
- `src/interfaces/schema/walk_schema.py`
  - `/api/walk/route` 요청에 `profile_name` 추가

2. 프롬프트 수정
- `extraction.yaml`에 자연어 표현별 `profile_name` 매핑 규칙 추가
- DB/엔진에 없는 `shade_score`, `scenery_score` 같은 값을 LLM이 임의로 생성하지 않도록 제한
- "그늘", "시원함" 등 현재 전용 프로필이 없는 요구는 임시로 `quiet`에 매핑하고 `unsupported_preferences`에 원 표현을 보존

3. 프론트엔드 payload 연결
- AI 챗봇 모드에서 `state.user_context.profile_name`을 `/api/walk/route` payload에 포함
- `profile_name == "child"`이면 `child_friendly=True`로 보정
- `DistancePreference`는 목적지 누락 에러 방지를 위해 우선 `circular`로 매핑

4. API 라우터 연결
- `walk_router.py`에서 `profile_name`을 정규화한 뒤 `RouteService.get_route(..., profile_name=...)`로 전달
- `child_friendly=True` 또는 `profile_name=="child"`이면 child 전용 엔진 분기로 라우팅

## 리뷰어 참고 사항
- 러닝 입력은 현재 walk route API에서 러닝 전용 엔진으로 안정적으로 연결되지 않아, 이번 PR에서는 `running` profile 매핑을 보류했습니다.
- 기존 `weight_assign.yaml` 및 `profiles.py`는 수정하지 않았습니다.
- 오래된 `route_flat` import 흔적은 현재 신규 `app.py` 실행 흐름에서 타지 않는 것으로 보여 이번 PR 범위에서는 제외했습니다.

## 통합 테스트 체크리스트
- [ ] Docker/PostgreSQL/Valkey 실행
- [ ] FastAPI 서버 실행
- [ ] Streamlit AI 챗봇 모드 실행
- [ ] "아이랑 걷고 싶어" 입력 시 child 분기 확인
- [ ] "무릎 아파서 평지로 걷고 싶어" 입력 시 flat profile payload 확인
- [ ] "3km 정도 걷고 싶어" 입력 시 circular 경로 생성 확인
