### PR TITLE
Fix/158

### DIFF
--- a/src/interfaces/schema/running_schema.py
+++ b/src/interfaces/schema/running_schema.py
@@ -1,0 +1,21 @@
+from typing import Optional
+from pydantic import BaseModel
+
+
+class CourseInfo(BaseModel):
+    id:                     int
+    name:                   str
+    course_type:            str
+    difficulty:             Optional[str] = None
+    start_lat:              float
+    start_lon:              float
+    distance_from_origin_m: float
+
+
+class OnewayRunningResponse(BaseModel):
+    courses:    list[CourseInfo] = []
+    total_km:   float = 0.0
+    mode:       str   = "oneway_running"
+
+
+RUNNING_COURSE_TYPES = ["river", "park", "bike_track", "trail"]

--- a/src/repository/layer/running_repository.py
+++ b/src/repository/layer/running_repository.py
@@ -94,14 +94,15 @@ class RunningRepository:
                 return []
 
         return [
-            CourseInfo(
-                id=row.id,
-                name=row.name,
-                course_type=row.course_type,
-                difficulty=row.difficulty,
-                start_lat=row.start_lat,
-                start_lon=row.start_lon,
-                distance_from_origin_m=round(row.distance_from_origin_m, 1),
-            )
+            {
+                "id":                     row.id,
+                "name":                   row.name,
+                "course_type":            row.course_type,
+                "difficulty":             row.difficulty,
+                "start_lat":              row.start_lat,
+                "start_lon":              row.start_lon,
+                "distance_from_origin_m": round(row.distance_from_origin_m, 1),
+            }
             for row in rows
         ]
+

--- a/src/repository/network/graph_repository.py
+++ b/src/repository/network/graph_repository.py
@@ -6,12 +6,12 @@ from sqlalchemy import select
 from src.database.postgresql import get_postgresql_db
 from src.entity.network.walk_edge import WalkEdge
 from src.entity.network.walk_node import WalkNode
-from src.route_engine.engines.path_utils import PathUtils
 
 
 class GraphRepository:
     @staticmethod
     def load_graph() -> nx.Graph:
+        from src.route_engine.engines.path_utils import PathUtils
         """
         walk_nodes + walk_edges를 PostGIS에서 읽어 NetworkX 그래프로 반환.
 

--- a/src/route_engine/profiles.py
+++ b/src/route_engine/profiles.py
@@ -36,4 +36,4 @@ PROFILES: dict[Union[CircularMode, OnewayMode], ProfileConfig] = {
 # ── 진입점 ────────────────────────────────────────────────
 
 def get_profile(profile_name: Union[str, OnewayMode, CircularMode]) -> ProfileConfig:
-    return PROFILES.get(profile_name, PROFILES["default"])
+    return PROFILES.get(profile_name, _DEFAULT)


### PR DESCRIPTION
## ☝️Issue Number
- resolve #158 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
챗봇에서 경로 생성 시 발생하는 서버 실행 오류 3종 수정.

1. `running_schema.py` 파일 누락으로 인한 ModuleNotFoundError 해결
   — `CourseInfo`, `OnewayRunningResponse`, `RUNNING_COURSE_TYPES` 정의 및
     `running_repository.py`의 반환값을 dict로 통일

2. `graph_repository` → `engines/__init__` → `oneway/running` → `graph_repository`
   순환 import로 인한 ImportError 해결
   — `PathUtils` import를 `load_graph()` 메서드 내부로 이동

3. `profiles.py` 리팩토링 이후 enum 키로 교체되면서 fallback `PROFILES["default"]`가
   KeyError 발생하던 문제 해결 — `_DEFAULT` 상수로 교체

