### PR TITLE
Feat: LangSmith 연동, 로그인 및 배너 버그 수정, 마이페이지 생성

### DIFF
--- a/frontend/streamlit_prototype/components/carousel/banner_carousel.py
+++ b/frontend/streamlit_prototype/components/carousel/banner_carousel.py
@@ -73,6 +73,9 @@ class BannerCarousel:
         """
         배너 캐러셀 HTML, 선택 버튼, 모달 팝업을 렌더링합니다.
         """
+        if not banners:
+            return
+
         st_html(self._build_html(banners), height=160)
 
         modal = Modal(key="banner_modal", title="")

--- a/frontend/streamlit_prototype/pages/mypage.py
+++ b/frontend/streamlit_prototype/pages/mypage.py
@@ -1,0 +1,143 @@
+"""
+frontend/streamlit_prototype/pages/mypage.py
+
+마이페이지 - 로그인 연동 버전
+- st.session_state 기반 로그인 게이트 적용
+- 로그아웃 API (POST /api/login/kakao/logout) 연동
+- TODO: GET /api/user/me 연동 후 display_id, created_at 실제 데이터로 교체
+- TODO: 산책기록팀 API 연동 후 산책 기록 섹션 실제 데이터로 교체
+"""
+
+import asyncio
+
+import httpx
+import streamlit as st
+
+_BACKEND_URL = "http://localhost:8000"
+_AUTH_KEYS = ("access_token", "refresh_token", "nickname", "initialized", "thread_id")
+
+
+def _clear_auth() -> None:
+    for key in _AUTH_KEYS:
+        st.session_state.pop(key, None)
+
+st.set_page_config(page_title="마이페이지", page_icon="👤", layout="wide")
+
+# ── 로그인 게이트 ─────────────────────────────────────────────────────────────
+if not st.session_state.get("access_token"):
+    st.warning("로그인이 필요합니다. 메인 페이지에서 로그인해주세요.")
+    st.stop()
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# ── Mock 데이터 ──────────────────────────────────────────────────────────────
+MOCK_STATS = {
+    "total_count": 12,
+    "total_km": 45.3,
+    "this_month_count": 3,
+}
+
+MOCK_HISTORY = [
+    {"date": "2024-06-20", "mode": "순환 랜덤",    "total_km": 4.2, "time_min": 63},
+    {"date": "2024-06-17", "mode": "편도 최단거리", "total_km": 2.8, "time_min": 42},
+    {"date": "2024-06-14", "mode": "순환 어린이",   "total_km": 3.5, "time_min": 53},
+    {"date": "2024-06-10", "mode": "편도 랜덤",     "total_km": 5.1, "time_min": 77},
+    {"date": "2024-06-05", "mode": "순환 러닝",     "total_km": 6.0, "time_min": 90},
+]
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _run_async(coro):
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)
+
+
+async def _call_logout():
+    """백엔드 로그아웃 API를 호출합니다."""
+    cookies = {}
+    access_token = st.session_state.get("access_token")
+    refresh_token = st.session_state.get("refresh_token")
+    if access_token:
+        cookies["access_token"] = access_token
+    if refresh_token:
+        cookies["refresh_token"] = refresh_token
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        await client.post(f"{_BACKEND_URL}/api/login/kakao/logout", cookies=cookies)
+
+
+def render_profile():
+    st.markdown("## 👤 프로필")
+
+    nickname = st.session_state.get("nickname", "알 수 없음")
+
+    col_info, col_btn = st.columns([3, 1])
+
+    with col_info:
+        st.markdown(f"**닉네임** &nbsp; {nickname}")
+        # TODO: GET /api/user/me 연동 후 display_id, created_at 실제 데이터로 교체
+
+    with col_btn:
+        if st.button("프로필 수정", use_container_width=True):
+            st.session_state["edit_profile"] = True
+
+    if st.session_state.get("edit_profile"):
+        with st.form("profile_form"):
+            new_nickname = st.text_input("닉네임", value=nickname)
+            submitted = st.form_submit_button("저장")
+            if submitted:
+                # TODO: PATCH /api/user/me 호출로 교체
+                st.success("저장되었습니다. (Mock)")
+                st.session_state["edit_profile"] = False
+
+
+def render_stats():
+    st.divider()
+    st.markdown("## 📊 산책 통계")
+
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        st.metric("총 산책 횟수", f"{MOCK_STATS['total_count']}회")
+    with col2:
+        st.metric("총 산책 거리", f"{MOCK_STATS['total_km']} km")
+    with col3:
+        st.metric("이번 달 산책", f"{MOCK_STATS['this_month_count']}회")
+
+
+def render_history():
+    st.divider()
+    st.markdown("## 🗓️ 산책 기록")
+
+    # TODO: GET /api/walk/history 호출로 교체
+    for record in MOCK_HISTORY:
+        with st.container(border=True):
+            col1, col2, col3, col4 = st.columns([2, 2, 1, 1])
+            with col1:
+                st.markdown(f"**{record['date']}**")
+            with col2:
+                st.markdown(record["mode"])
+            with col3:
+                st.markdown(f"{record.get('total_km', 0)} km")
+            with col4:
+                st.markdown(f"{record['time_min']} 분")
+
+
+def render_logout():
+    st.divider()
+    if st.button("로그아웃", type="secondary"):
+        with st.spinner("로그아웃 중..."):
+            try:
+                _run_async(_call_logout())
+            except Exception:
+                pass
+        _clear_auth()
+        st.rerun()
+
+
+render_profile()
+render_stats()
+render_history()
+render_logout()

--- a/frontend/streamlit_prototype/sections/auth.py
+++ b/frontend/streamlit_prototype/sections/auth.py
@@ -25,9 +25,9 @@ _COOKIE_MAX_AGE_DAYS = 14
 
 def get_cookie_manager() -> stx.CookieManager:
     """CookieManager 싱글톤. 위젯 중복(DuplicateWidgetID)을 막기 위해 1회만 생성합니다."""
-    if "cookie_manager" not in st.session_state:
-        st.session_state.cookie_manager = stx.CookieManager(key="cookie_manager")
-    return st.session_state.cookie_manager
+    if "_cookie_manager_instance" not in st.session_state:
+        st.session_state["_cookie_manager_instance"] = stx.CookieManager(key="cookie_manager")
+    return st.session_state["_cookie_manager_instance"]
 
 
 def _run_async(coro):

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,5 +1,50 @@
-import secrets
+import os
+from pydantic_settings import BaseSettings
 
-# SECRET_KEY 발급
-print(f"ACCESS_SECRET_KEY: {secrets.token_hex(32)}")
-print(f"REFRESH_SECRET_KEY: {secrets.token_hex(32)}")
+
+class Settings(BaseSettings):
+    # PostgreSQL
+    POSTGRES_USER: str = "postgres"
+    POSTGRES_PASSWORD: str = "postgres"
+    POSTGRES_DB: str = "seoul_walk"
+    POSTGRES_HOST: str = "localhost"
+    POSTGRES_PORT: int = 5434
+
+    # Valkey
+    VALKEY_URI: str = "redis://localhost:6379"
+
+    # Map
+    MAPBOX_API_KEY: str = ""
+    KAKAO_API_KEY: str = ""
+    KAKAO_REDIRECT_URI: str = "http://localhost:8501"
+
+    # Weather
+    WEATHER_API_KEY: str = ""
+    AIR_KOREA_API_KEY: str = ""
+
+    # OpenAI
+    OPENAI_API_KEY: str = ""
+
+    # Public Data
+    PUBLIC_DATA_API_KEY: str = ""
+
+    # JWT
+    ACCESS_SECRET_KEY: str = ""
+    REFRESH_SECRET_KEY: str = ""
+
+    # LangSmith
+    LANGCHAIN_TRACING_V2: str = "false"
+    LANGCHAIN_ENDPOINT: str = "https://api.smith.langchain.com"
+    LANGCHAIN_API_KEY: str = ""
+    LANGCHAIN_PROJECT: str = ""
+
+    model_config = {"env_file": ".env", "extra": "ignore"}
+
+
+settings = Settings()
+
+# LangChain이 import되기 전에 os.environ에 반영되어야 트레이싱이 활성화됨
+os.environ["LANGCHAIN_TRACING_V2"] = settings.LANGCHAIN_TRACING_V2
+os.environ["LANGCHAIN_ENDPOINT"] = settings.LANGCHAIN_ENDPOINT
+os.environ["LANGCHAIN_API_KEY"] = settings.LANGCHAIN_API_KEY
+os.environ["LANGCHAIN_PROJECT"] = settings.LANGCHAIN_PROJECT

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+from src.config.settings import settings  # noqa: F401 — LangSmith 트레이싱 활성화를 위해 최상단에 위치
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager


### PR DESCRIPTION
## ☝️Issue Number
- resolve #175 #176 #177 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
### 1. sections/auth.py — CookieManager 버그 수정

- 문제: st.session_state["cookie_manager"]가 위젯 키와 충돌해 StreamlitAPIException + AttributeError 발생
- 수정: session_state 저장 키를 "cookie_manager" → "_cookie_manager_instance"로 변경

### 2. components/carousel/banner_carousel.py — 빈 배너 방어 처리

- 문제: 배너 API가 빈 리스트를 반환할 때 st.columns(0) 호출로 StreamlitInvalidColumnSpecError 발생
- 수정: if not banners: return 추가

### 3. src/config/settings.py — 환경변수 중앙 관리 + LangSmith 연결

- 문제: 환경변수가 각 파일에 분산(load_dotenv())되어 있고 LangSmith 트레이싱 미활성화
- 수정: pydantic-settings 기반 Settings 클래스로 전체 환경변수 통합, LangSmith 관련 값을 os.environ에 즉시 반영

### 4. src/main.py — settings 최상단 import 추가

- 수정: from src.config.settings import settings를 첫 번째 줄에 추가 (LangSmith가 LangChain보다 먼저 초기화되도록)

### 5. pages/mypage.py — 신규 파일 (마이페이지 로그인 연동)

- 추가 내용:
 - 로그인 게이트: session_state.access_token 없으면 접근 차단
 - 닉네임: Mock → session_state.nickname 실제 값으로 교체
 - 로그아웃: POST /api/login/kakao/logout 호출 후 세션 초기화

---
### 추가 내용:
- 로그인 게이트: session_state.access_token 없으면 접근 차단
- 닉네임: Mock → session_state.nickname 실제 값으로 교체
- 로그아웃: POST /api/login/kakao/logout 호출 후 세션 초기화
