### PR TITLE
[Fix] 카카오 로그인 후 앱 전환 실패 및 토큰 갱신 플로우 수정

### DIFF
--- a/frontend/streamlit_prototype/api/auth_client.py
+++ b/frontend/streamlit_prototype/api/auth_client.py
@@ -21,7 +21,7 @@ def _is_access_expired(response: dict) -> bool:
     """응답이 access_token 만료를 의미하는지 판별합니다."""
     if not isinstance(response, dict):
         return False
-    if response.get("status") == "access_expired_token":
+    if response.get("status") in ("access_expired_token", "invalid_token"):
         return True
     if response.get("status") == "FAILED" and response.get("fallback_reason") == "access_expired_token":
         return True

--- a/frontend/streamlit_prototype/api/login_router.py
+++ b/frontend/streamlit_prototype/api/login_router.py
@@ -15,12 +15,11 @@ class LoginRouter:
             return response.json()
 
     async def kakao_callback(self, code: str):
-        """
-        카카오 로그인 콜백을 처리하고 access_token 및 refresh_token을 반환하는 API를 호출합니다.
-        """
         async with httpx.AsyncClient(timeout=60.0) as client:
             params = {"code": code}
             response = await client.get(f"{self.base_url}/kakao/callback", params=params)
             access_token = response.cookies.get("access_token")
             refresh_token = response.cookies.get("refresh_token")
+            if response.status_code != 200:
+                return {}, None, None
             return response.json(), access_token, refresh_token

--- a/frontend/streamlit_prototype/sections/auth.py
+++ b/frontend/streamlit_prototype/sections/auth.py
@@ -90,54 +90,42 @@ def _kakao_login_button_html(login_url: str) -> str:
     </div>
     '''
 
-
 def require_login() -> bool:
-    """
-    로그인 여부를 확인하고, 미로그인 시 카카오 로그인 UI를 렌더링합니다.
-
-    Returns:
-        bool: 로그인 완료 시 True, 그렇지 않으면 False.
-    """
-    cm = get_cookie_manager()
-    cookies = cm.get_all() or {}
-
-    # 1) 현재 세션에 토큰이 있으면 통과
+    # 1) session_state 체크 (stx 전혀 건드리지 않음)
     if st.session_state.get("access_token"):
         return True
 
-    # 2) 브라우저 쿠키에서 복원 (새로고침/재접속 시)
+    # 2) 카카오 인가 코드 처리 (stx 없이)
+    code = st.query_params.get("code")
+    if code and not st.session_state.get("_kakao_callback_done"):
+        st.session_state["_kakao_callback_done"] = True
+        login_router = LoginRouter()
+        with st.spinner("로그인 처리 중..."):
+            res, access_token, refresh_token = _run_async(login_router.kakao_callback(code))
+        if access_token:
+            st.session_state.access_token = access_token
+            st.session_state.refresh_token = refresh_token
+            st.session_state.nickname = res.get("nickname")
+            st.rerun()
+        else:
+            st.error("로그인에 실패했습니다. 다시 시도해주세요.")
+        return False
+
+    # 3) 브라우저 쿠키에서 복원 (새로고침/재접속 시)
+    cm = get_cookie_manager()
+    cookies = cm.get_all() or {}
     if cookies.get("access_token"):
         st.session_state.access_token = cookies.get("access_token")
         st.session_state.refresh_token = cookies.get("refresh_token")
         st.session_state.nickname = cookies.get("nickname")
         return True
 
+    # 4) 로그인 화면
     login_router = LoginRouter()
-
-    # 3) 카카오 인가 코드를 들고 리다이렉트로 돌아온 경우
-    code = st.query_params.get("code")
-    if code:
-        with st.spinner("로그인 처리 중..."):
-            res, access_token, refresh_token = _run_async(login_router.kakao_callback(code))
-
-        if access_token:
-            st.session_state.access_token = access_token
-            st.session_state.refresh_token = refresh_token
-            st.session_state.nickname = res.get("nickname")
-            _persist_tokens(cm, access_token, refresh_token, res.get("nickname"))
-            st.query_params.clear()
-            st.rerun()
-        else:
-            st.query_params.clear()
-            st.error("로그인에 실패했습니다. 다시 시도해주세요.")
-
-    # 4) 로그인 화면 — 카카오 버튼만 바로 노출
     url_res = _run_async(login_router.get_kakao_login_url())
     login_url = url_res.get("url") if url_res else None
-
     if login_url:
         st.markdown(_kakao_login_button_html(login_url), unsafe_allow_html=True)
     else:
         st.error("로그인 URL을 불러오지 못했습니다. 백엔드 서버 상태를 확인해주세요.")
-
     return False

--- a/src/agent/nodes/route_executor.py
+++ b/src/agent/nodes/route_executor.py
@@ -40,7 +40,8 @@ class RouteExecutor(GPTClient):
             k: Coordinate(lat=v["lat"], lon=v["lon"]) if k in ("origin", "destination") else v
             for k, v in state.user_context.model_dump(exclude={"mode", "purpose"}, exclude_none=True).items()
         }
-
+        
+        args["access_token"] = state.access_token or ""
         state.route_result = await self.route_tool.tool_map[tool_name].ainvoke(args)
 
         state.response = await super().get_response(

--- a/src/agent/tools/route_tools.py
+++ b/src/agent/tools/route_tools.py
@@ -19,65 +19,65 @@ class RouteTool:
         ]
         self.tool_map = {t.name: t for t in self.tools}
 
-    async def circular_random_route(self, origin: Coordinate, target_km: float = 3.0):
+    async def circular_random_route(self, origin: Coordinate, target_km: float = 3.0, access_token: str = ""):
         """
         출발지 주변을 랜덤하게 순환하는 경로를 생성합니다.
         특별한 조건 없이 자유롭게 산책하고 싶을 때 사용하세요.
         """
         return await asyncio.to_thread(
-            self.route_service.get_route, origin, None, target_km, CircularMode.RANDOM
+            self.route_service.get_route, access_token, origin, None, target_km, CircularMode.RANDOM
         )
 
-    async def circular_child_route(self, origin: Coordinate, target_km: float = 3.0):
+    async def circular_child_route(self, origin: Coordinate, target_km: float = 3.0, access_token: str = ""):
         """
         어린이 친화 순환 경로를 생성합니다.
         어린이보호구역·안전한 길을 우선하며, 어린이 동반 산책에 적합합니다.
         """
         return await asyncio.to_thread(
-            self.route_service.get_route, origin, None, target_km, CircularMode.CHILD
+            self.route_service.get_route, access_token, origin, None, target_km, CircularMode.CHILD
         )
 
-    async def circular_running_route(self, origin: Coordinate, target_km: float = 5.0):
+    async def circular_running_route(self, origin: Coordinate, target_km: float = 5.0, access_token: str = ""):
         """
         러닝·조깅에 적합한 순환 경로를 생성합니다.
         공원·하천 등 런닝 코스를 우선적으로 포함합니다.
         """
         return await asyncio.to_thread(
-            self.route_service.get_route, origin, None, target_km, CircularMode.RUNNING
+            self.route_service.get_route, access_token, origin, None, target_km, CircularMode.RUNNING
         )
 
-    async def oneway_shortest_route(self, origin: Coordinate, destination: Coordinate):
+    async def oneway_shortest_route(self, origin: Coordinate, destination: Coordinate, access_token: str = ""):
         """
         출발지에서 목적지까지 최단 경로를 생성합니다.
         목적지가 정해져 있고 빠르게 이동하고 싶을 때 사용하세요.
         """
         return await asyncio.to_thread(
-            self.route_service.get_route, origin, destination, None, OnewayMode.SHORTEST
+            self.route_service.get_route, access_token, origin, destination, None, OnewayMode.SHORTEST
         )
 
-    async def oneway_random_route(self, origin: Coordinate, destination: Coordinate, target_km: float = 3.0):
+    async def oneway_random_route(self, origin: Coordinate, destination: Coordinate, target_km: float = 3.0, access_token: str = ""):
         """
         출발지에서 목적지까지 목표 거리를 채우며 이동하는 경로를 생성합니다.
         목적지가 있지만 중간 경로를 다양하게 탐색하고 싶을 때 사용하세요.
         """
         return await asyncio.to_thread(
-            self.route_service.get_route, origin, destination, target_km, OnewayMode.RANDOM
+            self.route_service.get_route, access_token, origin, destination, target_km, OnewayMode.RANDOM
         )
 
-    async def oneway_child_route(self, origin: Coordinate, destination: Coordinate, target_km: float = 3.0):
+    async def oneway_child_route(self, origin: Coordinate, destination: Coordinate, target_km: float = 3.0, access_token: str = ""):
         """
         어린이 친화 편도 경로를 생성합니다.
         어린이보호구역·안전한 길을 우선하며 목적지로 이동합니다.
         """
         return await asyncio.to_thread(
-            self.route_service.get_route, origin, destination, target_km, OnewayMode.CHILD
+            self.route_service.get_route, access_token, origin, destination, target_km, OnewayMode.CHILD
         )
 
-    async def oneway_running_route(self, origin: Coordinate, destination: Coordinate, target_km: float = 5.0):
+    async def oneway_running_route(self, origin: Coordinate, destination: Coordinate, target_km: float = 5.0, access_token: str = ""):
         """
         러닝·조깅에 적합한 편도 경로를 생성합니다.
         공원·하천 런닝 코스를 우선 포함하며 목적지로 이동합니다.
         """
         return await asyncio.to_thread(
-            self.route_service.get_route, origin, destination, target_km, OnewayMode.RUNNING
+            self.route_service.get_route, access_token, origin, destination, target_km, OnewayMode.RUNNING
         )

--- a/src/interfaces/api/auth_router.py
+++ b/src/interfaces/api/auth_router.py
@@ -36,7 +36,7 @@ async def check_refresh_token(
         response.set_cookie(
             key="access_token",
             value=access_token,
-            httponly=True,
+            httponly=False,
             secure=False,  # 배포 시에는 True로 설정하여 HTTPS 환경에서만 전송되도록 수정
             samesite="lax",
             max_age=3600   # 1시간

--- a/src/interfaces/api/login_router.py
+++ b/src/interfaces/api/login_router.py
@@ -42,12 +42,11 @@ async def kakao_callback(
     response.set_cookie(
         key="refresh_token",
         value=refresh_token,
-        httponly=True,
+        httponly=False,  # stx.CookieManager가 JS로 읽어야 하므로 False
         secure=False,
         samesite="lax",
-        max_age=14 * 24 * 60 * 60  # 14일
+        max_age=14 * 24 * 60 * 60
     )
-
     return LoginResponse(status=Status.SUCCESS, token_type="Bearer", nickname=nickname)
 
 @router.post("/kakao/logout", response_model=AuthResponse)

--- a/src/schema/prewalk_schema.py
+++ b/src/schema/prewalk_schema.py
@@ -50,6 +50,7 @@ class State(BaseModel):
     """
     user_id: int
     current_location: Location
+    access_token: Optional[str] = None
 
     mode: Optional[Union[CircularMode, OnewayMode]] = None
     user_context: Optional[

--- a/src/service/chat/prewalk_service.py
+++ b/src/service/chat/prewalk_service.py
@@ -114,6 +114,7 @@ class PrewalkOrchestrator:
         
         # 최근 프롬프트로 업데이트
         state.user_prompt = user_prompt
+        state.access_token = access_token
 
         # state 업데이트
         result      = await self.graph.ainvoke(state)

--- a/src/service/route/route_service.py
+++ b/src/service/route/route_service.py
@@ -55,10 +55,10 @@ class RouteService:
         context에 적합한 경로 생성 엔진을 호출합니다.
         """
         # 사용자 인증
-        # status, provider, provider_id = self.auth_service.check_access_token(access_token)
-        # if status != Status.SUCCESS:
-        #     return WalkRouteResponse(status="FAILED", mode=mode, coordinates=[], total_km=0.0,
-        #                             fallback_reason=status)
+        status, provider, provider_id = self.auth_service.check_access_token(access_token)
+        if status != Status.SUCCESS:
+            return WalkRouteResponse(status="FAILED", mode=mode, coordinates=[], total_km=0.0,
+                                    fallback_reason=status)
         
         # 추후 사용자에게 추천한 경로를 저장하기 위해 필요
         # user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)


### PR DESCRIPTION
## ☝️Issue Number
- resolve #180 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- access_token이 경로 생성 파이프라인(State → route_executor → route_tools → route_service)에 전달되지 않아 인증이 항상 실패하던 버그 수정
- 카카오 OAuth 로그인 후 앱 화면이 전환되지 않던 버그 수정 (stx.CookieManager WebSocket 재연결로 인한 session_state 유실)
