### PR TITLE
[Feat] 온보딩 설문 기능 구현 (POST /api/user/survey)

### DIFF
--- a/src/entity/base.py
+++ b/src/entity/base.py
@@ -8,7 +8,7 @@ def register_entities():
     """
     Base.metadata에 모든 엔티티 테이블 정보를 등록합니다.
     """
-    from src.entity import chat_session, user
+    from src.entity import chat_session, user, user_preference
     from src.entity.network import walk_node, walk_edge
     from src.entity.layer import (
         safety_layer,

--- a/src/entity/user.py
+++ b/src/entity/user.py
@@ -2,12 +2,13 @@ from src.entity.base import Base
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy import Integer, String, DateTime, func, Enum, UniqueConstraint
 from datetime import datetime
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 import enum
 
 # 순환 참조를 방지하기 위해 타입 체크 시점에만 참조합니다.
 if TYPE_CHECKING:
     from src.entity.chat_session import ChatSession
+    from src.entity.user_preference import UserPreference
 
 class Provider(str, enum.Enum):
     KAKAO = "kakao"
@@ -51,5 +52,13 @@ class User(Base):
     chat_sessions: Mapped[List["ChatSession"]] = relationship(
         "ChatSession",
         back_populates="user",
+        cascade="all, delete-orphan"
+    )
+
+    # UserPreference와 1:1 관계를 설정합니다.
+    user_preference: Mapped[Optional["UserPreference"]] = relationship(
+        "UserPreference",
+        back_populates="user",
+        uselist=False,
         cascade="all, delete-orphan"
     )

--- a/src/entity/user_preference.py
+++ b/src/entity/user_preference.py
@@ -1,0 +1,46 @@
+"""
+src/entity/user_preference.py
+
+온보딩 설문 결과로 수집한 사용자 경로 선호도를 저장하는 엔티티.
+users 테이블과 1:1 관계이며, 설문 미완료 시 경로 추천은 기본 프로필(_DEFAULT)을 사용한다.
+"""
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import Boolean, Float, ForeignKey, Integer
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.entity.base import Base
+
+if TYPE_CHECKING:
+    from src.entity.user import User
+
+
+class UserPreference(Base):
+    """
+    사용자 경로 선호도를 관리하는 엔티티입니다.
+
+    온보딩 설문의 키워드 태그 선택 결과가 각 weights 컬럼에 저장됩니다.
+    null인 가중치는 경로 생성 시 기본값(0.5)으로 대체됩니다.
+    """
+    __tablename__ = "user_preferences"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+        index=True
+    )
+
+    survey_completed: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    default_target_km: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    weights_safety: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    weights_nature: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    weights_slope: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    weights_running: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    weights_landmark: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    weights_child: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    user: Mapped["User"] = relationship("User", back_populates="user_preference")

--- a/src/interfaces/api/user_router.py
+++ b/src/interfaces/api/user_router.py
@@ -1,6 +1,31 @@
-from fastapi import APIRouter
+"""
+src/interfaces/api/user_router.py
+
+/api/user 하위 엔드포인트 정의.
+현재 온보딩 설문 제출(POST /api/user/survey)을 제공합니다.
+"""
+from fastapi import APIRouter, Cookie, Depends
+
+from src.interfaces.dependencies import get_survey_service
+from src.interfaces.schema.survey_schema import SurveyRequest, SurveyResponse
+from src.service.user.survey_service import SurveyService
 
 router = APIRouter(
     prefix="/api/user",
     tags=["user"]
 )
+
+
+@router.post("/survey", response_model=SurveyResponse)
+def submit_survey(
+    request: SurveyRequest,
+    access_token: str = Cookie(None),
+    service: SurveyService = Depends(get_survey_service),
+):
+    """
+    온보딩 설문 결과를 제출합니다.
+
+    input : 키워드 태그 목록, 선호 거리 선택지
+    output: 저장된 사용자 가중치 프로필
+    """
+    return service.submit(access_token, request)

--- a/src/interfaces/dependencies.py
+++ b/src/interfaces/dependencies.py
@@ -7,7 +7,8 @@ from src.service import (
     PrewalkOrchestrator,
     RouteService,
     BannerService,
-    MapService
+    MapService,
+    SurveyService
 )
 from src.agent.nodes import (
     WeatherChecker,
@@ -30,6 +31,7 @@ banner_service      = BannerService(MarathonClient())
 kakao_client        = KakaoClient()
 weather_client      = WeatherClient(kakao_client)
 map_service         = MapService(kakao_client)
+survey_service      = SurveyService(auth_service)
 
 G = None
 route_service: Optional[RouteService] = None
@@ -78,3 +80,7 @@ def get_banner_service() -> BannerService:
 # 지도
 def get_map_service() -> MapService:
     return map_service
+
+# 온보딩 설문
+def get_survey_service() -> SurveyService:
+    return survey_service

--- a/src/interfaces/schema/survey_schema.py
+++ b/src/interfaces/schema/survey_schema.py
@@ -1,0 +1,53 @@
+"""
+src/interfaces/schema/survey_schema.py
+
+온보딩 설문 API의 요청/응답 스키마 정의.
+"""
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class DistanceOption(str, Enum):
+    """
+    선호 산책 거리 선택지입니다.
+    """
+    SLOW   = "slow"    # ~2km
+    NORMAL = "normal"  # 2–4km
+    FAST   = "fast"    # 4km+
+
+
+class SurveyStatus(str, Enum):
+    SUCCESS              = "success"
+    ACCESS_EXPIRED_TOKEN = "access_expired_token"
+    INVALID_TOKEN        = "invalid_token"
+    USER_NOT_FOUND       = "user_not_found"
+
+
+class SurveyRequest(BaseModel):
+    """
+    온보딩 설문 제출 요청 스키마입니다.
+
+    tags: 사용자가 선택한 키워드 태그 목록
+    distance: 선호 산책 거리 선택지 (선택 안 하면 null)
+    """
+    tags: List[str] = []
+    distance: Optional[DistanceOption] = None
+
+
+class SurveyResponse(BaseModel):
+    """
+    온보딩 설문 제출 응답 스키마입니다.
+
+    저장된 가중치 값을 그대로 반환합니다.
+    인증 실패 또는 오류 시 status만 반환되고 나머지 필드는 null입니다.
+    """
+    status: SurveyStatus
+    default_target_km: Optional[float] = None
+    weights_safety: Optional[float] = None
+    weights_nature: Optional[float] = None
+    weights_slope: Optional[float] = None
+    weights_running: Optional[float] = None
+    weights_landmark: Optional[float] = None
+    weights_child: Optional[float] = None

--- a/src/repository/user/user_preference_repository.py
+++ b/src/repository/user/user_preference_repository.py
@@ -1,0 +1,36 @@
+"""
+src/repository/user/user_preference_repository.py
+
+UserPreference 엔티티에 대한 DB 접근을 담당하는 리포지토리.
+"""
+from sqlalchemy import select
+
+from src.database.postgresql import get_postgresql_db
+from src.entity.user_preference import UserPreference
+
+
+class UserPreferenceRepository:
+    """
+    user_preferences 테이블에 대한 CRUD를 담당합니다.
+    """
+
+    @staticmethod
+    def upsert(user_id: int, **kwargs) -> UserPreference:
+        """
+        user_id 기준으로 선호도 레코드를 생성하거나 갱신합니다.
+        레코드가 없으면 INSERT, 있으면 kwargs 필드만 UPDATE합니다.
+        """
+        with get_postgresql_db() as db:
+            query = select(UserPreference).where(UserPreference.user_id == user_id)
+            preference = db.execute(query).scalar_one_or_none()
+
+            if preference is None:
+                preference = UserPreference(user_id=user_id, **kwargs)
+                db.add(preference)
+            else:
+                for key, value in kwargs.items():
+                    setattr(preference, key, value)
+
+            db.commit()
+            db.refresh(preference)
+            return preference

--- a/src/service/__init__.py
+++ b/src/service/__init__.py
@@ -5,3 +5,4 @@ from src.service.chat.prewalk_service import PrewalkOrchestrator
 from src.service.route.route_service import RouteService
 from src.service.route.banner_service import BannerService
 from src.service.route.map_service import MapService
+from src.service.user.survey_service import SurveyService

--- a/src/service/user/survey_service.py
+++ b/src/service/user/survey_service.py
@@ -1,0 +1,122 @@
+"""
+src/service/user/survey_service.py
+
+온보딩 설문 비즈니스 로직을 담당하는 서비스.
+키워드 태그를 경로 가중치로 변환하고 UserPreference에 저장한다.
+"""
+from src.interfaces.schema.auth_schema import Status
+from src.interfaces.schema.survey_schema import DistanceOption, SurveyRequest, SurveyResponse, SurveyStatus
+from src.repository.user.user_preference_repository import UserPreferenceRepository
+from src.repository.user.user_repository import UserRepository
+from src.service.user.auth_service import AuthService
+
+TAG_WEIGHT_MAP: dict[str, dict[str, float]] = {
+    # nature: 자연 친화도
+    "나무 많은":     {"nature":   +0.2},
+    "꽃길":          {"nature":   +0.2},
+    "햇살 좋은":     {"nature":   +0.2},
+    "그늘이 많은":   {"nature":   +0.1},
+
+    # safety: 안전성 (조용하거나 골목길은 안전 가중치 하향 또는 분리)
+    "밤에도 안전한": {"safety":   +0.2},
+    "큰길":          {"safety":   +0.2},
+    "밝은 길":       {"safety":   +0.2},
+    "골목골목":      {"safety":  -0.1},
+
+    # slope & running: 경사도 및 활동성
+    "숨 안 차는":    {"slope":    +0.3}, # 평지 선호 (상승고도 회피)
+    "평탄한":        {"slope":    +0.2},
+    "뛰고 싶은":     {"running":  +0.2, "slope":  -0.1}, # 경사 수용, 러닝 적합
+    "운동":         {"running":  +0.2, "slope":  -0.2}, # 가파른 경사도 수용
+
+    # landmark: 볼거리 및 혼잡도
+    "볼거리 많은":   {"landmark": +0.2},
+    "인스타 감성":   {"landmark": +0.2},
+    "조용한":       {"landmark": -0.2, "safety":  -0.1}, # 한적하지만 인적이 드물 수 있음
+    "야경이 예쁜":   {"landmark": +0.2, "safety":  +0.1},  # 야간 안전 확보된 명소
+
+    # 동반자 중심 복합 필터
+    "어린이":       {"child":    +0.2, "slope":  +0.1},  # 평지 선호 포함
+    "반려동물":     {"nature":   +0.1, "child":  +0.1},
+    "유모차":       {"child":    +0.1, "slope":    +0.3, "safety": +0.1},
+    "휠체어":       {"slope":    +0.3, "safety": +0.1},   # 계단 및 경사 절대 회피
+
+    # 감성 / 분위기 (Mood)
+    "활기찬":        {"landmark": +0.2, "safety":  +0.1},  # 유동인구가 많고 활력 있는 길
+    "사색하기 좋은":  {"landmark": -0.2, "slope":   +0.1},  # 조용하고 평탄하여 걷기 좋은 길
+    "힙한":          {"landmark": +0.25},  # 트렌디한 상권이나 팝업스토어 주변
+
+    # 색상 / 시각적 이미지 (Visual Color)
+    "노랑":          {"nature":   +0.15, "landmark": +0.1}, # 따뜻함, 은행나무, 봄꽃, 조명
+    "분홍":          {"nature":   +0.25, "landmark": +0.1}, # 벚꽃길, 장미터널 등 개화 시기 저격
+    "파랑":          {"nature": +0.1},                      # 청량함, 한강변, 호수공원, 해안도로
+    "초록":          {"nature":   +0.3}                     # 숲길, 대형 공원 등 자연 극대화
+}
+
+DISTANCE_MAP: dict[DistanceOption, float] = {
+    DistanceOption.SLOW:   2.0,
+    DistanceOption.NORMAL: 3.0,
+    DistanceOption.FAST:   5.0,
+}
+
+BASE_WEIGHTS: dict[str, float] = {
+    "safety":   0.5,
+    "nature":   0.5,
+    "slope":    0.5,
+    "running":  0.5,
+    "landmark": 0.5,
+    "child":    0.5,
+}
+
+
+class SurveyService:
+    """
+    온보딩 설문 제출을 처리하는 서비스입니다.
+    """
+
+    def __init__(self, auth_service: AuthService):
+        self.auth_service = auth_service
+
+    def submit(self, access_token: str | None, request: SurveyRequest) -> SurveyResponse:
+        """
+        설문 결과를 가중치로 변환해 UserPreference에 저장합니다.
+
+        모든 가중치는 0.5에서 시작하며, 각 태그는 TAG_WEIGHT_MAP의 delta(±0.2)로 조정됩니다.
+        최종값은 [0.0, 1.0]으로 클램핑됩니다.
+        """
+
+        status, provider, provider_id = self.auth_service.check_access_token(access_token)
+        if status != Status.SUCCESS:
+            return SurveyResponse(status=status)
+
+        user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)
+        if user is None:
+            return SurveyResponse(status=SurveyStatus.USER_NOT_FOUND)
+        
+        weights = dict(BASE_WEIGHTS)
+        for tag in request.tags:
+            for key, delta in TAG_WEIGHT_MAP.get(tag, {}).items():
+                weights[key] = max(0.0, min(1.0, weights[key] + delta))
+
+        preference = UserPreferenceRepository.upsert(
+            user_id=user.id,
+            survey_completed=True,
+            default_target_km=DISTANCE_MAP.get(request.distance) if request.distance else None,
+            weights_safety=weights.get("safety"),
+            weights_nature=weights.get("nature"),
+            weights_slope=weights.get("slope"),
+            weights_running=weights.get("running"),
+            weights_landmark=weights.get("landmark"),
+            weights_child=weights.get("child"),
+        )
+
+        return SurveyResponse(
+            status=SurveyStatus.SUCCESS,
+            default_target_km=preference.default_target_km,
+            weights_safety=preference.weights_safety,
+            weights_nature=preference.weights_nature,
+            weights_slope=preference.weights_slope,
+            weights_running=preference.weights_running,
+            weights_landmark=preference.weights_landmark,
+            weights_child=preference.weights_child,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,7 @@ for _mod in [
     # Repository (geoalchemy2/h3 의존)
     "src.repository.utils",
     "src.repository.user.user_repository",
+    "src.repository.user.user_preference_repository",
     "src.repository.chat.chat_session_repository",
     "src.repository.layer.child_repository",
     "src.repository.layer.landmark_repository",

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -28,6 +28,7 @@ from src.interfaces.schema.walk_schema import (
     FallbackReason,
 )
 from src.interfaces.schema.auth_schema import Status
+from src.interfaces.schema.survey_schema import SurveyResponse, SurveyStatus
 from src.service.user.auth_service import AuthService
 
 # ── 공통 픽스처 ──────────────────────────────────────────────────────────────
@@ -424,4 +425,61 @@ class TestMapEdgesAPI:
 
     def test_lat_lon_누락_시_422_반환(self, client):
         response = client.get("/api/map/edges")
+        assert response.status_code == 422
+
+
+# ── POST /api/user/survey ────────────────────────────────────────────────────
+
+class TestSurveyAPI:
+    def test_설문_정상_제출(self, client):
+        mock_service = MagicMock()
+        mock_service.submit.return_value = SurveyResponse(
+            status=SurveyStatus.SUCCESS,
+            default_target_km=3.0,
+            weights_nature=0.9,
+            weights_slope=0.5,
+        )
+        with patch("src.interfaces.dependencies.survey_service", mock_service):
+            response = client.post(
+                "/api/user/survey",
+                json={
+                    "tags": ["나무 많은", "초록초록"],
+                    "distance": "normal",
+                },
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "success"
+        assert body["default_target_km"] == 3.0
+        assert body["weights_nature"] == 0.9
+
+    def test_태그_없이_제출하면_성공(self, client):
+        mock_service = MagicMock()
+        mock_service.submit.return_value = SurveyResponse(
+            status=SurveyStatus.SUCCESS,
+        )
+        with patch("src.interfaces.dependencies.survey_service", mock_service):
+            response = client.post("/api/user/survey", json={})
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+
+    def test_만료된_토큰이면_ACCESS_EXPIRED_TOKEN_반환(self, client):
+        mock_service = MagicMock()
+        mock_service.submit.return_value = SurveyResponse(
+            status=SurveyStatus.ACCESS_EXPIRED_TOKEN,
+        )
+        with patch("src.interfaces.dependencies.survey_service", mock_service):
+            response = client.post(
+                "/api/user/survey",
+                json={"tags": []},
+                cookies={"access_token": "expired.token"},
+            )
+        assert response.status_code == 200
+        assert response.json()["status"] == "access_expired_token"
+
+    def test_유효하지_않은_distance_값이면_422_반환(self, client):
+        response = client.post(
+            "/api/user/survey",
+            json={"tags": [], "distance": "invalid_option"},
+        )
         assert response.status_code == 422

--- a/tests/unit/test_survey_service.py
+++ b/tests/unit/test_survey_service.py
@@ -1,0 +1,229 @@
+"""
+tests/unit/test_survey_service.py
+SurveyService 단위 테스트
+
+검증 항목:
+  - 인증 실패 시 status 반환
+  - 사용자 미존재 시 USER_NOT_FOUND 반환
+  - 태그 없을 때 모든 가중치 기본값 0.5
+  - 단일 태그 가중치 적용
+  - 동일 가중치 여러 태그 누적
+  - 가중치 최대값 1.0 클램핑
+  - 음수 델타 적용 (slope -)
+  - 가중치 최소값 0.0 클램핑
+  - 알 수 없는 태그 무시
+  - 이중 dimension 태그
+  - slope 양수/음수 태그 혼합
+  - 거리 선택지 → default_target_km 매핑
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.service.user.survey_service import SurveyService
+from src.interfaces.schema.survey_schema import SurveyRequest, SurveyStatus, DistanceOption
+from src.interfaces.schema.auth_schema import Status
+from src.entity.user import Provider
+
+
+# ── 픽스처 ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def auth_service():
+    return MagicMock()
+
+
+@pytest.fixture
+def service(auth_service):
+    return SurveyService(auth_service)
+
+
+@pytest.fixture
+def mock_user():
+    user = MagicMock()
+    user.id = 1
+    return user
+
+
+@pytest.fixture
+def mock_preference():
+    pref = MagicMock()
+    pref.survey_completed = True
+    pref.default_target_km = None
+    pref.weights_safety = None
+    pref.weights_nature = None
+    pref.weights_slope = None
+    pref.weights_running = None
+    pref.weights_landmark = None
+    pref.weights_child = None
+    return pref
+
+
+def _get_upsert_kwargs(service, auth_service, mock_user, mock_preference, tags, distance=None):
+    """설문 제출 후 upsert에 전달된 kwargs를 반환하는 헬퍼."""
+    auth_service.check_access_token.return_value = (Status.SUCCESS, Provider.KAKAO, "kakao-123")
+    with patch(
+        "src.service.user.survey_service.UserRepository.find_by_provider_and_provider_id",
+        return_value=mock_user,
+    ):
+        with patch(
+            "src.service.user.survey_service.UserPreferenceRepository.upsert",
+            return_value=mock_preference,
+        ) as mock_upsert:
+            service.submit("valid_token", SurveyRequest(tags=tags, distance=distance))
+            return mock_upsert.call_args.kwargs
+
+
+# ── 인증 / 사용자 조회 실패 ───────────────────────────────────────────────────
+
+
+class TestSubmitAuth:
+    def test_INVALID_TOKEN이면_즉시_반환한다(self, service, auth_service):
+        auth_service.check_access_token.return_value = (Status.INVALID_TOKEN, None, None)
+        result = service.submit("bad_token", SurveyRequest())
+        assert result.status == SurveyStatus.INVALID_TOKEN
+
+    def test_ACCESS_EXPIRED_TOKEN이면_즉시_반환한다(self, service, auth_service):
+        auth_service.check_access_token.return_value = (Status.ACCESS_EXPIRED_TOKEN, None, None)
+        result = service.submit("expired_token", SurveyRequest())
+        assert result.status == SurveyStatus.ACCESS_EXPIRED_TOKEN
+
+    def test_사용자_없으면_USER_NOT_FOUND를_반환한다(self, service, auth_service):
+        auth_service.check_access_token.return_value = (Status.SUCCESS, Provider.KAKAO, "kakao-123")
+        with patch(
+            "src.service.user.survey_service.UserRepository.find_by_provider_and_provider_id",
+            return_value=None,
+        ):
+            result = service.submit("valid_token", SurveyRequest())
+        assert result.status == SurveyStatus.USER_NOT_FOUND
+
+
+# ── 가중치 계산 ──────────────────────────────────────────────────────────────
+
+
+class TestCalculateWeights:
+    def test_태그_없으면_모든_가중치가_0_5다(
+        self, service, auth_service, mock_user, mock_preference
+    ):
+        kwargs = _get_upsert_kwargs(service, auth_service, mock_user, mock_preference, tags=[])
+        assert kwargs["weights_safety"]   == pytest.approx(0.5)
+        assert kwargs["weights_nature"]   == pytest.approx(0.5)
+        assert kwargs["weights_slope"]    == pytest.approx(0.5)
+        assert kwargs["weights_running"]  == pytest.approx(0.5)
+        assert kwargs["weights_landmark"] == pytest.approx(0.5)
+        assert kwargs["weights_child"]    == pytest.approx(0.5)
+
+    def test_단일_태그가_가중치에_적용된다(
+        self, service, auth_service, mock_user, mock_preference
+    ):
+        # "나무 많은" → nature +0.2 → 0.7
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference, tags=["나무 많은"]
+        )
+        assert kwargs["weights_nature"] == pytest.approx(0.7)
+        assert kwargs["weights_safety"] == pytest.approx(0.5)  # 나머지 불변
+
+    def test_같은_가중치_여러_태그가_누적된다(
+        self, service, auth_service, mock_user, mock_preference
+    ):
+        # "나무 많은"(+0.2) + "꽃길"(+0.2) → nature 0.9
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference, tags=["나무 많은", "꽃길"]
+        )
+        assert kwargs["weights_nature"] == pytest.approx(0.9)
+
+    def test_가중치_최대값이_1_0으로_클램핑된다(
+        self, service, auth_service, mock_user, mock_preference
+    ):
+        # nature 태그 4개 → 0.5 + 0.8 = 1.3 → 클램핑 → 1.0
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference,
+            tags=["나무 많은", "꽃길", "햇살 좋은", "나무 많은"],
+        )
+        assert kwargs["weights_nature"] == pytest.approx(1.0)
+
+    def test_음수_델타가_적용된다(
+        self, service, auth_service, mock_user, mock_preference
+    ):
+        # "뛰고 싶은" → running +0.2 → 0.7, slope -0.1 → 0.4
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference, tags=["뛰고 싶은"]
+        )
+        assert kwargs["weights_running"] == pytest.approx(0.7)  # 0.6 → 0.7
+        assert kwargs["weights_slope"]   == pytest.approx(0.4)
+
+    def test_가중치_최소값이_0_0으로_클램핑된다(
+        self, service, auth_service, mock_user, mock_preference
+    ):
+        # slope 음수 태그 10개 → 0.0 미만 방지
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference,
+            tags=["뛰고 싶은"] * 10,
+        )
+        assert kwargs["weights_slope"] >= 0.0
+
+    def test_알_수_없는_태그는_무시된다(
+        self, service, auth_service, mock_user, mock_preference
+    ):
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference, tags=["존재하지않는태그"]
+        )
+        assert kwargs["weights_nature"] == pytest.approx(0.5)
+
+    def test_이중_dimension_태그가_두_가중치에_반영된다(
+        self, service, auth_service, mock_user, mock_preference
+    ):
+        # "반려동물" → nature +0.1 → 0.6, child +0.1 → 0.6
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference, tags=["반려동물"]  # "반려동물과" → "반려동물"
+        )
+        assert kwargs["weights_nature"] == pytest.approx(0.6)
+        assert kwargs["weights_child"]  == pytest.approx(0.6)
+
+
+    def test_slope_양수_음수_태그가_함께_적용된다(
+        self, service, auth_service, mock_user, mock_preference
+    ):
+        # "숨 안 차는"(+0.3) + "뛰고 싶은"(-0.1) → 0.5 + 0.3 - 0.1 = 0.7
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference,
+            tags=["숨 안 차는", "뛰고 싶은"],
+        )
+        assert kwargs["weights_slope"] == pytest.approx(0.7)
+
+    def test_설문_완료_시_survey_completed가_True다(
+        self, service, auth_service, mock_user, mock_preference
+    ):
+        kwargs = _get_upsert_kwargs(service, auth_service, mock_user, mock_preference, tags=[])
+        assert kwargs["survey_completed"] is True
+
+
+# ── 거리 매핑 ────────────────────────────────────────────────────────────────
+
+
+class TestDistanceMapping:
+    def test_slow는_2_0km다(self, service, auth_service, mock_user, mock_preference):
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference,
+            tags=[], distance=DistanceOption.SLOW,
+        )
+        assert kwargs["default_target_km"] == 2.0
+
+    def test_normal은_3_0km다(self, service, auth_service, mock_user, mock_preference):
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference,
+            tags=[], distance=DistanceOption.NORMAL,
+        )
+        assert kwargs["default_target_km"] == 3.0
+
+    def test_fast는_5_0km다(self, service, auth_service, mock_user, mock_preference):
+        kwargs = _get_upsert_kwargs(
+            service, auth_service, mock_user, mock_preference,
+            tags=[], distance=DistanceOption.FAST,
+        )
+        assert kwargs["default_target_km"] == 5.0
+
+    def test_distance_없으면_None이다(self, service, auth_service, mock_user, mock_preference):
+        kwargs = _get_upsert_kwargs(service, auth_service, mock_user, mock_preference, tags=[])
+        assert kwargs["default_target_km"] is None


### PR DESCRIPTION
## ☝️Issue Number
- resolve #188 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- UserPreference 엔티티 추가 (users 테이블과 1:1, 경로 가중치 저장)
- POST /api/user/survey 엔드포인트 구현
- 키워드 태그 → 가중치 변환 로직 (BASE 0.5, ±delta, [0,1] 클램핑)
- 통합 테스트(TestSurveyAPI) 및 유닛 테스트(TestSurveyService) 추가
