### PR TITLE
Feat: Banner Service 수정 및 편도 경로(다익스트라) 버그 수정

### DIFF
--- a/frontend/streamlit_prototype/api/banner_router.py
+++ b/frontend/streamlit_prototype/api/banner_router.py
@@ -2,7 +2,7 @@
 frontend/streamlit_prototype/api/banner_router.py
 
 GET /api/banner HTTP 클라이언트 래퍼
-날씨 상태와 시각을 전달해 배너 목록을 동기 방식으로 조회
+위치 좌표를 전달해 배너 목록을 동기 방식으로 조회
 """
 import httpx
 from frontend.streamlit_prototype.api.base_url import base_url
@@ -12,15 +12,15 @@ class BannerRouter:
     def __init__(self):
         self.base_url = f"{base_url}/api/banner"
 
-    def get_banner_list(self, weather_status: str, weather_msg: str, hour: int | None = None) -> list:
+    def get_banner_list(self, lat: float, lon: float, hour: int | None = None) -> list:
         """
-        input : weather_status, weather_msg, hour (선택)
+        input : lat (float), lon (float), hour (선택)
         output: [{"emoji", "text", "sub", ...}, ...] 또는 실패 시 []
 
         GET /api/banner 호출 후 배너 목록 반환
         """
         try:
-            params = {"weather_status": weather_status, "weather_msg": weather_msg}
+            params = {"lat": lat, "lon": lon}
             if hour is not None:
                 params["hour"] = hour
             return httpx.get(self.base_url, params=params, timeout=10.0).json()

--- a/frontend/streamlit_prototype/components/carousel/banner_data_carousel.py
+++ b/frontend/streamlit_prototype/components/carousel/banner_data_carousel.py
@@ -2,7 +2,7 @@
 frontend/streamlit_prototype/components/carousel/banner_data_carousel.py
 
 배너 목록을 API를 통해 조회하고 렌더링하는 캐러셀 컴포넌트
-날씨 상태와 현재 시각을 기반으로 배너 목록을 구성
+위치 좌표를 기반으로 배너 목록을 구성
 """
 from datetime import datetime
 
@@ -16,19 +16,9 @@ class BannerDataCarousel:
     def __init__(self):
         self._router = BannerRouter()
 
-    @st.cache_data(ttl=3600)
-    def get_events_cached(_self) -> list:
+    def get_banner_list(self, lat: float, lon: float, hour: int | None = None) -> list:
         """
-        input : 없음
-        output: list (마라톤 이벤트 목록)
-
-        GET /api/banner를 통해 이벤트 포함 배너 목록을 캐싱해 반환
-        """
-        return _self._router.get_banner_list("", "")
-
-    def get_banner_list(self, weather: dict, hour: int | None = None) -> list:
-        """
-        input : weather (weather_status, weather_msg 포함 dict), hour (선택)
+        input : lat (float), lon (float), hour (선택)
         output: [{"emoji", "text", "sub", ...}, ...]
 
         GET /api/banner 호출 후 배너 목록 반환
@@ -37,8 +27,4 @@ class BannerDataCarousel:
         if hour is None:
             hour = datetime.now().hour
 
-        return self._router.get_banner_list(
-            weather_status=weather.get("weather_status", ""),
-            weather_msg=weather.get("weather_msg", ""),
-            hour=hour,
-        )
+        return self._router.get_banner_list(lat=lat, lon=lon, hour=hour)

--- a/frontend/streamlit_prototype/providers/base.py
+++ b/frontend/streamlit_prototype/providers/base.py
@@ -36,7 +36,7 @@ class EnvProvider(ABC):
     """
 
     @abstractmethod
-    def get_banners(self, env: EnvData) -> list: ...
+    def get_banners(self, env: EnvData, lat: float = 0.0, lon: float = 0.0) -> list: ...
     """
     input : env (EnvData)
     output: list

--- a/frontend/streamlit_prototype/providers/weather_api.py
+++ b/frontend/streamlit_prototype/providers/weather_api.py
@@ -68,11 +68,11 @@ class WeatherEnvProvider(EnvProvider):
             air_raw=air,
         )
 
-    def get_banners(self, env: EnvData) -> list:
+    def get_banners(self, env: EnvData, lat: float = 0.0, lon: float = 0.0) -> list:
         """
-        input : env (EnvData)
+        input : env (EnvData), lat (float), lon (float)
         output: list
 
-        EnvData를 dict로 변환해 BannerDataCarousel에서 배너 리스트를 조회하여 반환
+        위치 좌표를 기반으로 배너 리스트를 조회하여 반환
         """
-        return self._banner_data.get_banner_list(dataclasses.asdict(env))
+        return self._banner_data.get_banner_list(lat=lat, lon=lon)

--- a/frontend/streamlit_prototype/sections/header.py
+++ b/frontend/streamlit_prototype/sections/header.py
@@ -21,7 +21,7 @@ def render_header(ctx: AppContext) -> tuple[float, float, EnvData]:
     t = time.time()
     lat, lng = ctx.walk_route_map.get_location()
     env      = ctx.provider.fetch(lat, lng)
-    banners  = ctx.provider.get_banners(env)
+    banners  = ctx.provider.get_banners(env, lat=lat, lon=lng)
     ctx.banner_carousel.render(banners)
     print(f"weather+banner: {time.time()-t:.2f}s")
     return lat, lng, env

--- a/src/entity/banner.py
+++ b/src/entity/banner.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import Integer, String, JSON
+from src.entity.base import Base
+
+
+class Banner(Base):
+    __tablename__ = "banners"
+
+    id:       Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    key:      Mapped[str] = mapped_column(String(50),  nullable=False, unique=True)
+    category: Mapped[str] = mapped_column(String(20),  nullable=False)
+    emoji:    Mapped[str] = mapped_column(String(10),  nullable=False)
+    text:     Mapped[str] = mapped_column(String(100), nullable=False)
+    sub:      Mapped[str] = mapped_column(String(100), nullable=False)
+    scoring:  Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "key":     self.key,
+            "emoji":   self.emoji,
+            "text":    self.text,
+            "sub":     self.sub,
+            "scoring": self.scoring,
+        }

--- a/src/entity/base.py
+++ b/src/entity/base.py
@@ -8,7 +8,7 @@ def register_entities():
     """
     Base.metadata에 모든 엔티티 테이블 정보를 등록합니다.
     """
-    from src.entity import chat_session, user, user_preference
+    from src.entity import chat_session, user, user_preference, banner
     from src.entity.network import walk_node, walk_edge
     from src.entity.layer import (
         safety_layer,
@@ -52,3 +52,6 @@ def init_db():
     """
     register_entities()
     init_table()
+
+    from src.repository.banner.banner_repository import BannerRepository
+    BannerRepository.seed()

--- a/src/interfaces/api/banner_router.py
+++ b/src/interfaces/api/banner_router.py
@@ -1,4 +1,3 @@
-from datetime import datetime, date
 import traceback
 from typing import Optional
 
@@ -12,46 +11,13 @@ router = APIRouter(tags=["banner"])
 
 @router.get("/api/banner")
 async def get_banner(
-    weather_status: str = "",
-    weather_msg: str = "",
+    lat: float,
+    lon: float,
     hour: Optional[int] = None,
     service: BannerService = Depends(get_banner_service),
 ):
     try:
-        if hour is None:
-            hour = datetime.now().hour
-
-        banners = []
-
-        # 이벤트 배너
-        today  = date.today()
-        events = await service._fetch_all_events()
-        for event in events:
-            diff = (event.date - today).days
-            if -1 <= diff <= 14:
-                banners.append(service._get_event_text({**event.model_dump(), "diff": diff}))
-                break
-
-        # 시즌 배너
-        if service._is_hot(weather_msg):
-            if 6 <= hour < 9:
-                banners.append(service.BANNERS["season"]["hot_morning"])
-            elif service._is_humid(weather_status):
-                banners.append(service.BANNERS["season"]["hot_humid"])
-            else:
-                banners.append(service.BANNERS["season"]["hot_sunny"])
-
-        # 고정 배너
-        keys = (
-            ["dog", "healing"] if hour < 17
-            else ["dog", "healing", "night"] if hour < 21
-            else ["night"]
-        )
-        for key in keys:
-            banners.append(service.BANNERS["fixed"][key])
-
-        return banners
-
+        return await service.get_banner_list(lat, lon, hour)
     except Exception as e:
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/interfaces/dependencies.py
+++ b/src/interfaces/dependencies.py
@@ -27,9 +27,9 @@ from src.repository.network.graph_repository import GraphRepository
 auth_service        = AuthService()
 user_service        = UserService(auth_service)
 kakao_login_service = KakaoLoginService(user_service, auth_service)
-banner_service      = BannerService(MarathonClient())
 kakao_client        = KakaoClient()
 weather_client      = WeatherClient(kakao_client)
+banner_service      = BannerService(MarathonClient(), weather_client)
 map_service         = MapService(kakao_client)
 survey_service      = SurveyService(auth_service)
 

--- a/src/repository/banner/banner_repository.py
+++ b/src/repository/banner/banner_repository.py
@@ -1,0 +1,58 @@
+from sqlalchemy import select
+from src.database.postgresql import get_postgresql_db
+from src.entity.banner import Banner
+
+
+_SEED_DATA = [
+    {
+        "key": "hot_sunny", "category": "season",
+        "emoji": "🌳", "text": "오늘 덥죠? 그늘 가득한 숲길 어떠세요?", "sub": "더위를 피하는 나만의 산책 코스",
+        "scoring": {"mode": "general", "weights": {"safety": 1.0, "nature": 2.5, "slope": 2.0, "landmark": 0.0, "child": 0.0, "running": 0.0}, "blocked_tags": []},
+    },
+    {
+        "key": "hot_humid", "category": "season",
+        "emoji": "🌊", "text": "습한 날엔 물가 바람이 최고예요", "sub": "시원한 물가 코스 추천",
+        "scoring": {"mode": "general", "weights": {"safety": 1.0, "nature": 2.0, "slope": 1.5, "landmark": 0.5, "child": 0.0, "running": 0.0}, "blocked_tags": []},
+    },
+    {
+        "key": "hot_morning", "category": "season",
+        "emoji": "🌅", "text": "더워지기 전에 먼저 걸어볼까요?", "sub": "상쾌한 새벽 산책 코스",
+        "scoring": {"mode": "general", "weights": {"safety": 1.5, "nature": 1.5, "slope": 1.5, "landmark": 0.0, "child": 0.0, "running": 0.0}, "blocked_tags": []},
+    },
+    {
+        "key": "dog", "category": "fixed",
+        "emoji": "🐶", "text": "강아지랑 함께 걷기 좋은 길이에요", "sub": "반려견 동반 가능 코스",
+        "scoring": {"mode": "general", "weights": {"safety": 2.0, "nature": 1.0, "slope": 1.5, "landmark": 0.0, "child": 2.0, "running": 0.0}, "blocked_tags": []},
+    },
+    {
+        "key": "healing", "category": "fixed",
+        "emoji": "🌿", "text": "조용하게 걷고 싶을 때 추천해요", "sub": "힐링 숲길 코스",
+        "scoring": {"mode": "general", "weights": {"safety": 1.5, "nature": 2.5, "slope": 2.0, "landmark": 0.0, "child": 0.0, "running": 0.0}, "blocked_tags": []},
+    },
+    {
+        "key": "night", "category": "fixed",
+        "emoji": "🌃", "text": "저녁에 걷기 좋은 야경 코스예요", "sub": "야경 명소 산책로",
+        "scoring": {"mode": "general", "weights": {"safety": 2.0, "nature": 0.5, "slope": 1.0, "landmark": 3.0, "child": 0.0, "running": 0.0}, "blocked_tags": []},
+    },
+]
+
+
+class BannerRepository:
+    @staticmethod
+    def find_all() -> list[Banner]:
+        with get_postgresql_db() as db:
+            return db.execute(select(Banner)).scalars().all()
+
+    @staticmethod
+    def find_by_key(key: str) -> Banner | None:
+        with get_postgresql_db() as db:
+            return db.execute(select(Banner).where(Banner.key == key)).scalar_one_or_none()
+
+    @staticmethod
+    def seed():
+        with get_postgresql_db() as db:
+            if db.execute(select(Banner)).first():
+                return
+            for data in _SEED_DATA:
+                db.merge(Banner(**data))
+            db.commit()

--- a/src/route_engine/engines/oneway/dijkstra.py
+++ b/src/route_engine/engines/oneway/dijkstra.py
@@ -54,7 +54,7 @@ class OnewayDijkstraEngine:
                                fallback_reason=FallbackReason.NO_PATH)
 
         target_km = self._inp.target_km or 3.0
-        total_m   = self._calc_distance(nodes)
+        total_m   = self._utils.calc_distance(nodes)
 
         # 최단경로가 목표의 60% 미만이면 우회 경로로 대체
         # 출발·도착이 가까울 때 지나치게 짧은 경로가 반환되는 문제 방지
@@ -62,7 +62,7 @@ class OnewayDijkstraEngine:
             fallback = self._utils.oneway_waypoint_path(start, end, target_km)
             if fallback:
                 nodes   = fallback
-                total_m = self._calc_distance(nodes)
+                total_m = self._utils.calc_distance(nodes)
 
         coords = self._utils.extract_coordinates(nodes)
         return WalkRouteResponse(

--- a/src/service/route/banner_service.py
+++ b/src/service/route/banner_service.py
@@ -1,66 +1,32 @@
-from src.infrastructure.external.client.marathon_client import MarathonClient
-from src.infrastructure.external.schema.marathon_schema import MarathonEvent
-from src.infrastructure.external.schema.weather_schema import EnvironmentInfo
 from datetime import datetime, date
-import asyncio
 import re
+
+from src.infrastructure.external.client.marathon_client import MarathonClient
+from src.infrastructure.external.client.weather_client import WeatherClient
+from src.infrastructure.external.schema.marathon_schema import MarathonEvent
+from src.repository.banner.banner_repository import BannerRepository
 
 
 class BannerService:
 
-    BANNERS = {
-        "season": {
-            "hot_sunny":   {"emoji": "🌳", "text": "오늘 덥죠? 그늘 가득한 숲길 어떠세요?",  "sub": "더위를 피하는 나만의 산책 코스"},
-            "hot_humid":   {"emoji": "🌊", "text": "습한 날엔 물가 바람이 최고예요",         "sub": "시원한 물가 코스 추천"},
-            "hot_morning": {"emoji": "🌅", "text": "더워지기 전에 먼저 걸어볼까요?",         "sub": "상쾌한 새벽 산책 코스"},
-        },
-        "fixed": {
-            "dog":     {"emoji": "🐶", "text": "강아지랑 함께 걷기 좋은 길이에요",         "sub": "반려견 동반 가능 코스"},
-            "healing": {"emoji": "🌿", "text": "조용하게 걷고 싶을 때 추천해요",           "sub": "힐링 숲길 코스"},
-            "night":   {"emoji": "🌃", "text": "저녁에 걷기 좋은 야경 코스예요",           "sub": "야경 명소 산책로"},
-        }
-    }
-
-    def __init__(self, marathon_client: MarathonClient):
-        """
-        BannerService 초기화
-        """
+    def __init__(self, marathon_client: MarathonClient, weather_client: WeatherClient):
         self.marathon_client = marathon_client
+        self.weather_client  = weather_client
 
     # ── 이벤트 관련 메서드 ─────────────────────────────────────
 
-    async def _fetch_all_events(self) -> list[dict]:
-        """
-        서울/경기/인천 이벤트를 병렬로 조회
-        """
-        results = await asyncio.gather(
-            self.marathon_client.get_events("서울"),
-            self.marathon_client.get_events("경기"),
-            self.marathon_client.get_events("인천"),
-        )
-        return [event for region_events in results for event in region_events]
+    async def _fetch_all_events(self) -> list[MarathonEvent]:
+        return await self.marathon_client.get_events("서울")
 
-    def get_events(self) -> list[MarathonEvent]:
-        """
-        이벤트 목록을 조회합니다.
-        """
-        return asyncio.run(self._fetch_all_events())
-
-    def get_active_event(self) -> dict | None:
-        """
-        D-14 이내 이벤트 반환
-        """
+    async def get_active_event(self) -> dict | None:
         today = date.today()
-        for event in self.get_events():
+        for event in await self._fetch_all_events():
             diff = (event.date - today).days
             if -1 <= diff <= 14:
                 return {**event.model_dump(), "diff": diff}
         return None
 
     def _get_event_text(self, event: dict) -> dict:
-        """
-        이벤트 정보를 배너 텍스트 형식으로 변환합니다.
-        """
         diff       = event["diff"]
         name       = event["name"]
         loc        = event["location"]
@@ -88,11 +54,9 @@ class BannerService:
 
     # ── 날씨 헬퍼 메서드 ───────────────────────────────────────
 
-    def _is_hot(self, weather_msg: str) -> bool:
-        """
-        weather_msg에서 기온을 파싱해 23도 이상이면 True 반환
-        """
-        match = re.search(r"[-+]?\d+(\.\d+)?", weather_msg)
+    def _is_hot(self, weather: dict) -> bool:
+        temp_str = weather.get("기온", "")
+        match = re.search(r"[-+]?\d+(\.\d+)?", temp_str)
         if match:
             try:
                 return float(match.group()) >= 23
@@ -100,57 +64,47 @@ class BannerService:
                 pass
         return False
 
-    def _is_humid(self, weather_status: str) -> bool:
-        """
-        날씨 상태에 흐림/습함 관련 키워드가 있으면 True 반환
-        """
+    def _is_humid(self, weather: dict) -> bool:
+        status   = weather.get("강수형태", "")
         keywords = ["흐림", "구름", "습", "비"]
-        return any(k in weather_status for k in keywords)
+        return any(k in status for k in keywords)
 
     # ── 메인 메서드 ────────────────────────────────────────────
 
-    def get_banner(self, weather: EnvironmentInfo, hour: int | None = None) -> dict:
-        """
-        단일 배너 반환 (하위 호환용)
-        """
-        banners = self.get_banner_list(weather, hour)
-        return banners[0] if banners else self.BANNERS["fixed"]["healing"]
-
-    def get_banner_list(self, weather: EnvironmentInfo, hour: int | None = None) -> list:
-        """
-        홈 화면에 노출할 배너 목록 전체를 반환합니다.
-        우선순위: 이벤트 → 시즌 → 고정
-        """
+    async def get_banner_list(self, lat: float, lon: float, hour: int | None = None) -> list:
         if hour is None:
             hour = datetime.now().hour
 
-        status  = weather.weather_status
-        msg     = weather.weather_msg
-        banners = []
+        weather = await self.weather_client.get_weather(lat, lon) or {}
+        banners = {b.key: b for b in BannerRepository.find_all()}
+        result  = []
 
         # 1순위: 이벤트 배너
-        active_event = self.get_active_event()
+        active_event = await self.get_active_event()
         if active_event:
-            banners.append(self._get_event_text(active_event))
+            result.append(self._get_event_text(active_event))
 
         # 2순위: 시즌 배너 (날씨 기반)
-        if self._is_hot(msg):
+        if self._is_hot(weather):
             if 6 <= hour < 9:
-                banners.append(self.BANNERS["season"]["hot_morning"])
-            elif self._is_humid(status):
-                banners.append(self.BANNERS["season"]["hot_humid"])
+                key = "hot_morning"
+            elif self._is_humid(weather):
+                key = "hot_humid"
             else:
-                banners.append(self.BANNERS["season"]["hot_sunny"])
+                key = "hot_sunny"
+            if key in banners:
+                result.append(banners[key].to_dict())
 
-        # 3순위: 고정 배너 (시간대 기반 전체 추가)
+        # 3순위: 고정 배너 (시간대 기반)
         if hour < 17:
-            keys = ["dog", "healing"]
+            fixed_keys = ["dog", "healing"]
         elif hour < 21:
-            keys = ["dog", "healing", "night"]
+            fixed_keys = ["dog", "healing", "night"]
         else:
-            keys = ["night"]
+            fixed_keys = ["night"]
 
-        for key in keys:
-            banners.append(self.BANNERS["fixed"][key])
+        for key in fixed_keys:
+            if key in banners:
+                result.append(banners[key].to_dict())
 
-        return banners
+        return result


### PR DESCRIPTION
## ☝️Issue Number
- resolve #185

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
### 신규 파일:
- src/entity/banner.py — Banner 엔티티 (key, category, emoji, text, sub, scoring JSON)
- src/repository/banner/banner_repository.py — find_all(), find_by_key(), seed() + 6개 배너 초기 데이터

### 수정 파일:
- src/entity/base.py — register_entities()에 banner 등록, init_db()에서 BannerRepository.seed() 호출
- src/interfaces/dependencies.py — kakao_client/weather_client를 먼저 선언 후 BannerService에 주입 (중복 인스턴스 제거)
- src/service/route/banner_service.py — weather_client 주입, 하드코딩 제거 → DB 조회, _is_hot()/_is_humid()가 dict 기반으로 수정, _fetch_all_events() 서울만 조회, 전체 메서드 async화
- src/interfaces/api/banner_router.py — weather_status/weather_msg 대신 lat/lon 수신, 로직 서비스로 위임
- frontend/streamlit_prototype/api/banner_router.py — lat/lon 파라미터로 변경
- frontend/streamlit_prototype/components/carousel/banner_data_carousel.py — lat/lon 기반으로 변경
- frontend/streamlit_prototype/providers/weather_api.py — get_banners()에 lat/lon 추가
- frontend/streamlit_prototype/providers/base.py — ABC 시그니처 맞춤
- frontend/streamlit_prototype/sections/header.py — get_banners(env, lat=lat, lon=lng) 호출