### PR TITLE
[Fix] 카카오 로그인 새로고침 시 KOE320 에러 수정

### DIFF
--- a/frontend/streamlit_prototype/sections/auth.py
+++ b/frontend/streamlit_prototype/sections/auth.py
@@ -106,6 +106,7 @@ def require_login() -> bool:
             st.session_state.access_token = access_token
             st.session_state.refresh_token = refresh_token
             st.session_state.nickname = res.get("nickname")
+            st.query_params.clear()
             st.rerun()
         else:
             st.error("로그인에 실패했습니다. 다시 시도해주세요.")


### PR DESCRIPTION
## ☝️Issue Number
- resolve #193

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- st.query_params.clear() 추가로 로그인 후 새로고침 시 만료된 인가 코드 재전송 방지