### PR TITLE
Feat: 마이페이지 GET /api/user/me, PATCH /api/user/me 구현 및 프론트 연동

### DIFF
--- a/frontend/streamlit_prototype/api/user_router.py
+++ b/frontend/streamlit_prototype/api/user_router.py
@@ -1,0 +1,26 @@
+import httpx
+
+from frontend.streamlit_prototype.api.base_url import base_url
+
+
+class UserRouter:
+    def __init__(self):
+        self.base_url = f"{base_url}/api/user"
+
+    async def get_me(self, access_token: str) -> dict:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            cookies = {"access_token": access_token} if access_token else {}
+            response = await client.get(f"{self.base_url}/me", cookies=cookies)
+            response.raise_for_status()
+            return response.json()
+
+    async def patch_me(self, access_token: str, nickname: str) -> dict:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            cookies = {"access_token": access_token} if access_token else {}
+            response = await client.patch(
+                f"{self.base_url}/me",
+                json={"nickname": nickname},
+                cookies=cookies,
+            )
+            response.raise_for_status()
+            return response.json()

--- a/frontend/streamlit_prototype/pages/mypage.py
+++ b/frontend/streamlit_prototype/pages/mypage.py
@@ -4,7 +4,8 @@ frontend/streamlit_prototype/pages/mypage.py
 마이페이지 - 로그인 연동 버전
 - st.session_state 기반 로그인 게이트 적용
 - 로그아웃 API (POST /api/login/kakao/logout) 연동
-- TODO: GET /api/user/me 연동 후 display_id, created_at 실제 데이터로 교체
+- GET /api/user/me 연동
+- PATCH /api/user/me 연동
 - TODO: 산책기록팀 API 연동 후 산책 기록 섹션 실제 데이터로 교체
 """
 
@@ -13,8 +14,12 @@ import asyncio
 import httpx
 import streamlit as st
 
+from frontend.streamlit_prototype.api.user_router import UserRouter
+from frontend.streamlit_prototype.api.auth_client import call_with_auto_refresh
+
 _BACKEND_URL = "http://localhost:8000"
 _AUTH_KEYS = ("access_token", "refresh_token", "nickname", "initialized", "thread_id")
+_user_router = UserRouter()
 
 
 def _clear_auth() -> None:
@@ -72,13 +77,18 @@ async def _call_logout():
 def render_profile():
     st.markdown("## 👤 프로필")
 
-    nickname = st.session_state.get("nickname", "알 수 없음")
+    me = _run_async(call_with_auto_refresh(_user_router.get_me))
+    if me.get("status") != "success":
+        st.error("사용자 정보를 불러오지 못했습니다.")
+        return
+
+    nickname = me.get("nickname") or st.session_state.get("nickname", "알 수 없음")
+    st.session_state["nickname"] = nickname
 
     col_info, col_btn = st.columns([3, 1])
 
     with col_info:
         st.markdown(f"**닉네임** &nbsp; {nickname}")
-        # TODO: GET /api/user/me 연동 후 display_id, created_at 실제 데이터로 교체
 
     with col_btn:
         if st.button("프로필 수정", use_container_width=True):
@@ -89,9 +99,18 @@ def render_profile():
             new_nickname = st.text_input("닉네임", value=nickname)
             submitted = st.form_submit_button("저장")
             if submitted:
-                # TODO: PATCH /api/user/me 호출로 교체
-                st.success("저장되었습니다. (Mock)")
-                st.session_state["edit_profile"] = False
+                result = _run_async(
+                    call_with_auto_refresh(
+                        lambda token: _user_router.patch_me(token, new_nickname)
+                    )
+                )
+                if result.get("status") == "success":
+                    st.session_state["nickname"] = result.get("nickname", new_nickname)
+                    st.success("저장되었습니다.")
+                    st.session_state["edit_profile"] = False
+                    st.rerun()
+                else:
+                    st.error("저장에 실패했습니다.")
 
 
 def render_stats():

--- a/src/interfaces/api/user_router.py
+++ b/src/interfaces/api/user_router.py
@@ -6,14 +6,39 @@ src/interfaces/api/user_router.py
 """
 from fastapi import APIRouter, Cookie, Depends
 
-from src.interfaces.dependencies import get_survey_service
+from src.interfaces.dependencies import get_survey_service, get_user_service
 from src.interfaces.schema.survey_schema import SurveyRequest, SurveyResponse
+from src.interfaces.schema.user_schema import UserMeResponse, UserUpdateRequest, UserUpdateResponse
 from src.service.user.survey_service import SurveyService
+from src.service.user.user_service import UserService
 
 router = APIRouter(
     prefix="/api/user",
     tags=["user"]
 )
+
+
+@router.get("/me", response_model=UserMeResponse)
+def get_me(
+    access_token: str = Cookie(None),
+    service: UserService = Depends(get_user_service),
+):
+    """
+    온보딩 설문 결과를 제출합니다.
+
+    input : 키워드 태그 목록, 선호 거리 선택지
+    output: 저장된 사용자 가중치 프로필
+    """
+    return service.get_me(access_token)
+
+
+@router.patch("/me", response_model=UserUpdateResponse)
+def update_me(
+    request: UserUpdateRequest,
+    access_token: str = Cookie(None),
+    service: UserService = Depends(get_user_service),
+):
+    return service.update_me(access_token, request.nickname)
 
 
 @router.post("/survey", response_model=SurveyResponse)
@@ -22,10 +47,4 @@ def submit_survey(
     access_token: str = Cookie(None),
     service: SurveyService = Depends(get_survey_service),
 ):
-    """
-    온보딩 설문 결과를 제출합니다.
-
-    input : 키워드 태그 목록, 선호 거리 선택지
-    output: 저장된 사용자 가중치 프로필
-    """
     return service.submit(access_token, request)

--- a/src/interfaces/schema/user_schema.py
+++ b/src/interfaces/schema/user_schema.py
@@ -1,8 +1,44 @@
-from pydantic import BaseModel
+from enum import Enum
 from typing import Optional
+
+from pydantic import BaseModel, field_validator
 
 from src.interfaces.schema.auth_schema import Status
 
+
 class UserResponse(BaseModel):
     status: Status
+    nickname: Optional[str] = None
+
+
+class UserStatus(str, Enum):
+    SUCCESS              = "success"
+    ACCESS_EXPIRED_TOKEN = "access_expired_token"
+    INVALID_TOKEN        = "invalid_token"
+    USER_NOT_FOUND       = "user_not_found"
+    INVALID_NICKNAME     = "invalid_nickname"
+
+
+class UserMeResponse(BaseModel):
+    status: UserStatus
+    nickname: Optional[str] = None
+    survey_completed: Optional[bool] = None
+
+
+class UserUpdateRequest(BaseModel):
+    nickname: str
+
+    @field_validator("nickname")
+    @classmethod
+    def validate_nickname(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("닉네임을 입력해 주세요.")
+        if len(v) > 50:
+            raise ValueError("닉네임은 50자 이내로 입력해 주세요.")
+        return v
+
+
+class UserUpdateResponse(BaseModel):
+    status: UserStatus
     nickname: Optional[str] = None

--- a/src/repository/user/user_preference_repository.py
+++ b/src/repository/user/user_preference_repository.py
@@ -15,6 +15,16 @@ class UserPreferenceRepository:
     """
 
     @staticmethod
+    def find_survey_completed(user_id: int) -> bool:
+        """
+        user_id 기준으로 설문 완료 여부를 반환합니다. 레코드가 없으면 False를 반환합니다.
+        """
+        with get_postgresql_db() as db:
+            query = select(UserPreference.survey_completed).where(UserPreference.user_id == user_id)
+            result = db.execute(query).scalar_one_or_none()
+            return result if result is not None else False
+
+    @staticmethod
     def upsert(user_id: int, **kwargs) -> UserPreference:
         """
         user_id 기준으로 선호도 레코드를 생성하거나 갱신합니다.

--- a/src/repository/user/user_repository.py
+++ b/src/repository/user/user_repository.py
@@ -33,3 +33,21 @@ class UserRepository:
                 User.provider_id==provider_id
             )
             return db.execute(query).scalar_one_or_none()
+
+    @staticmethod
+    def update_nickname(provider: Provider, provider_id: str, nickname: str):
+        """
+        사용자의 닉네임을 수정합니다.
+        """
+        with get_postgresql_db() as db:
+            query = select(User).where(
+                User.provider==provider,
+                User.provider_id==provider_id
+            )
+            user = db.execute(query).scalar_one_or_none()
+            if user is None:
+                return None
+            user.nickname = nickname
+            db.commit()
+            db.refresh(user)
+            return user

--- a/src/service/user/user_service.py
+++ b/src/service/user/user_service.py
@@ -1,14 +1,16 @@
-from uuid import uuid4
-
 from src.repository.user.user_repository import UserRepository
+from src.repository.user.user_preference_repository import UserPreferenceRepository
 from src.infrastructure.cache.repository.user_repository import UserRepository as CacheUserRepository
 from src.entity.user import User, Provider
 from src.service.user.auth_service import AuthService
+from src.interfaces.schema.auth_schema import Status
+from src.interfaces.schema.user_schema import UserMeResponse, UserUpdateResponse, UserStatus
+
 
 class UserService:
     def __init__(self, auth_service: AuthService):
         self.auth_service = auth_service
-    
+
     async def save(
         self,
         provider: Provider,
@@ -21,6 +23,43 @@ class UserService:
         """
         user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)
         await CacheUserRepository.save_refresh_token(provider, provider_id, refresh_token)
-        
+
         if user is None:
             return UserRepository.save(provider, provider_id, nickname)
+
+    def get_me(self, access_token: str | None) -> UserMeResponse:
+        """
+        로그인한 사용자의 닉네임과 설문 완료 여부를 반환합니다.
+        """
+        status, provider, provider_id = self.auth_service.check_access_token(access_token)
+        if status != Status.SUCCESS:
+            return UserMeResponse(status=UserStatus(status.value))
+
+        user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)
+        if user is None:
+            return UserMeResponse(status=UserStatus.USER_NOT_FOUND)
+
+        survey_completed = UserPreferenceRepository.find_survey_completed(user.id)
+
+        return UserMeResponse(
+            status=UserStatus.SUCCESS,
+            nickname=user.nickname,
+            survey_completed=survey_completed,
+        )
+
+    def update_me(self, access_token: str | None, nickname: str) -> UserUpdateResponse:
+        """
+        로그인한 사용자의 닉네임을 수정합니다.
+        """
+        status, provider, provider_id = self.auth_service.check_access_token(access_token)
+        if status != Status.SUCCESS:
+            return UserUpdateResponse(status=UserStatus(status.value))
+
+        user = UserRepository.update_nickname(provider, provider_id, nickname)
+        if user is None:
+            return UserUpdateResponse(status=UserStatus.USER_NOT_FOUND)
+
+        return UserUpdateResponse(
+            status=UserStatus.SUCCESS,
+            nickname=user.nickname,
+        )


### PR DESCRIPTION
## ☝️Issue Number
- resolve #200 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- GET /api/user/me: access_token 쿠키로 인증 후 nickname, survey_completed 반환
- PATCH /api/user/me: nickname 수정 (빈 값·50자 초과 유효성 검사 포함)
- UserPreferenceRepository.find_survey_completed() 추가 (세션 종료 후 lazy loading 방지)
- Streamlit 마이페이지 프로필 섹션 mock 제거, access_token 만료 시 자동 재발급 처리

## Changed files
**백엔드**
- `src/interfaces/schema/user_schema.py` — UserStatus, UserMeResponse, UserUpdateRequest, UserUpdateResponse 추가
- `src/interfaces/api/user_router.py` — GET /me, PATCH /me 엔드포인트 추가
- `src/service/user/user_service.py` — get_me(), update_me() 추가
- `src/repository/user/user_repository.py` — update_nickname() 추가
- `src/repository/user/user_preference_repository.py` — find_survey_completed() 추가

**프론트**
- `frontend/streamlit_prototype/api/user_router.py` — 신규 생성, get_me() / patch_me() HTTP 호출
- `frontend/streamlit_prototype/pages/mypage.py` — 프로필 섹션 mock 제거 및 실제 API 연동

## Out of scope
- GET /api/walk/history — 산책 기록 담당자 작업 완료 후 별도 PR로 연동
