### PR TITLE
[REFACTOR] WalkMode와 scoring profile 분리

### DIFF
--- a/src/agent/tools/route_tools.py
+++ b/src/agent/tools/route_tools.py
@@ -3,6 +3,7 @@ from typing import Optional
 from langchain_core.tools import StructuredTool
 
 from src.interfaces.schema.walk_schema import WalkMode, Coordinate
+from src.route_engine.profiles import ScoringProfile
 from src.schema.route_schema import Weights
 
 
@@ -18,29 +19,29 @@ class RouteTool:
         ]
         self.tool_map = {t.name: t for t in self.tools}
 
-    async def circular_random_route(self, origin: Coordinate, target_km: float = 3.0, access_token: str = "", custom_weights: Optional[Weights] = None):
+    async def circular_random_route(self, origin: Coordinate, target_km: float = 3.0, access_token: str = "", custom_weights: Optional[Weights] = None, profile: Optional[ScoringProfile] = None):
         """
         출발지 주변을 랜덤하게 순환하는 경로를 생성합니다.
         특별한 조건 없이 자유롭게 산책하고 싶을 때 사용하세요.
         """
         return await asyncio.to_thread(
-            self.route_service.get_route, access_token, origin, None, target_km, WalkMode.CIRCULAR_RANDOM, custom_weights
+            self.route_service.get_route, access_token, origin, None, target_km, WalkMode.CIRCULAR_RANDOM, custom_weights, profile
         )
 
-    async def oneway_shortest_route(self, origin: Coordinate, destination: Coordinate, access_token: str = "", custom_weights: Optional[Weights] = None):
+    async def oneway_shortest_route(self, origin: Coordinate, destination: Coordinate, access_token: str = "", custom_weights: Optional[Weights] = None, profile: Optional[ScoringProfile] = None):
         """
         출발지에서 목적지까지 최단 경로를 생성합니다.
         목적지가 정해져 있고 빠르게 이동하고 싶을 때 사용하세요.
         """
         return await asyncio.to_thread(
-            self.route_service.get_route, access_token, origin, destination, None, WalkMode.ONEWAY_SHORTEST, custom_weights
+            self.route_service.get_route, access_token, origin, destination, None, WalkMode.ONEWAY_SHORTEST, custom_weights, profile
         )
 
-    async def oneway_random_route(self, origin: Coordinate, destination: Coordinate, target_km: float = 3.0, access_token: str = "", custom_weights: Optional[Weights] = None):
+    async def oneway_random_route(self, origin: Coordinate, destination: Coordinate, target_km: float = 3.0, access_token: str = "", custom_weights: Optional[Weights] = None, profile: Optional[ScoringProfile] = None):
         """
         출발지에서 목적지까지 목표 거리를 채우며 이동하는 경로를 생성합니다.
         목적지가 있지만 중간 경로를 다양하게 탐색하고 싶을 때 사용하세요.
         """
         return await asyncio.to_thread(
-            self.route_service.get_route, access_token, origin, destination, target_km, WalkMode.ONEWAY_RANDOM, custom_weights
+            self.route_service.get_route, access_token, origin, destination, target_km, WalkMode.ONEWAY_RANDOM, custom_weights, profile
         )

--- a/src/interfaces/api/walk_router.py
+++ b/src/interfaces/api/walk_router.py
@@ -55,7 +55,10 @@ async def walk_route(
                     validate_no_highway(request.destination.lat, request.destination.lon, db)
                 destination = Coordinate.model_construct(lat=dest_lat, lon=dest_lon)
 
-        response = service.get_route(access_token, origin, destination, request.target_km, request.mode)
+        response = service.get_route(
+            access_token, origin, destination, request.target_km, request.mode,
+            profile=request.profile,
+        )
         logger.info("walk route response completed: mode=%s status=%s", request.mode, response.status.value)
         return response
     except HTTPException:

--- a/src/interfaces/schema/walk_schema.py
+++ b/src/interfaces/schema/walk_schema.py
@@ -18,6 +18,7 @@ from src.interfaces.validators.mode_validator import (
     sanitize_circular_destination,
     validate_oneway_requires_destination,
 )
+from src.route_engine.profiles import ScoringProfile
 
 
 class Coordinate(BaseModel):
@@ -68,6 +69,7 @@ class WalkRouteRequest(BaseModel):
     destination: Optional[Coordinate] = None
     target_km: Optional[float] = None
     mode: WalkMode
+    profile: Optional[ScoringProfile] = None
 
     @field_validator("target_km", mode="before")
     @classmethod

--- a/src/route_engine/README.md
+++ b/src/route_engine/README.md
@@ -22,7 +22,18 @@
 - FastAPI 라우터나 Streamlit 뷰 파일 임포트 금지
 - 기존 `src/service/route` 파일 꼬리물기 식 임포트 금지
 
-## 6. 추후 마이그레이션 순서
+## 6. WalkMode vs ScoringProfile
+경로 생성 방식과 점수 선호도는 서로 다른 축이며 독립적으로 조합됩니다.
+
+- **WalkMode** (`src/interfaces/schema/walk_schema.py`): 경로를 *어떻게* 만들지 결정합니다.
+  - `circular_random`, `oneway_shortest`, `oneway_random` 3개로 고정되어 있으며, 각각 별도의 엔진(`engines/circular_random.py`, `engines/dijkstra.py`, `engines/oneway_random.py`)에 매핑됩니다.
+- **ScoringProfile** (`profiles.py`): 경로 비용을 계산할 때 *어떤 score를 선호*할지 결정합니다.
+  - `default`, `nature`, `safe`, `flat`, `running`, `landmark` 6개이며, `ProfileConfig.weights`/`blocked_tags`/`scoring_mode`로 정의됩니다.
+  - 어떤 WalkMode를 쓰든 같은 ScoringProfile은 항상 같은 weights를 줍니다(`get_profile(profile)`이 WalkMode를 모릅니다).
+- 3개 엔진 생성자는 `(custom_weights, profile)`을 받아 `merge_weights(profile.weights, custom_weights)`로 최종 weights를 계산합니다. `custom_weights`는 명시적으로 지정한 필드만 profile 위에 override하고(부분 병합), 나머지는 profile의 base weights를 그대로 씁니다.
+- `scoring_engine.py`의 계산 공식(`general`/`running` 분기)은 그대로이며, `ProfileConfig.scoring_mode`로 어느 분기를 쓸지만 선택합니다(현재 `running` profile만 `"running"` 분기 사용).
+
+## 7. 추후 마이그레이션 순서
 1. Skeleton 완성 (현재)
 2. 팀원들이 본인 로직을 Skeleton으로 복사 (병렬 작업)
 3. 충분한 테스트 후 API Gateway의 라우터 연결점을 기존 로직에서 `route_orchestrator.py`로 점진 전환

--- a/src/route_engine/engines/circular_random.py
+++ b/src/route_engine/engines/circular_random.py
@@ -3,7 +3,7 @@ import random
 from typing import Optional
 
 from src.route_engine.engines.path_utils import PathUtils
-from src.route_engine.profiles import get_profile
+from src.route_engine.profiles import ScoringProfile, get_profile, merge_weights
 from src.interfaces.schema.walk_schema import (
     WalkMode,
     WalkRouteStatus,
@@ -19,14 +19,16 @@ class CircularRandomEngine:
         inp: CircularRouteInput,
         G: nx.Graph,
         custom_weights: Optional[Weights] = None,
+        profile: Optional[ScoringProfile] = None,
     ):
-        self.inp          = inp
-        self.G            = G.copy()  # 원본 그래프 보호
-        self.utils        = PathUtils(self.G)
-        self.mode         = WalkMode.CIRCULAR_RANDOM
-        profile           = get_profile(self.mode)
-        self.weights      = custom_weights or profile.weights
-        self.blocked_tags = profile.blocked_tags
+        self.inp           = inp
+        self.G             = G.copy()  # 원본 그래프 보호
+        self.utils         = PathUtils(self.G)
+        self.mode          = WalkMode.CIRCULAR_RANDOM
+        profile_config     = get_profile(profile)
+        self.weights       = merge_weights(profile_config.weights, custom_weights)
+        self.blocked_tags  = profile_config.blocked_tags
+        self.scoring_mode  = profile_config.scoring_mode
 
     def run(self) -> WalkRouteResponse:
         """
@@ -34,7 +36,7 @@ class CircularRandomEngine:
         """
         # 엣지별 custom_score 기록 (in-place)
         calculate_custom_score(self.G, {
-            "mode": "general",
+            "mode": self.scoring_mode,
             "weights": self.weights,
             "blocked_tags": self.blocked_tags,
         })

--- a/src/route_engine/engines/dijkstra.py
+++ b/src/route_engine/engines/dijkstra.py
@@ -2,7 +2,7 @@ import networkx as nx
 from typing import Optional
 
 from src.route_engine.engines.path_utils import PathUtils
-from src.route_engine.profiles import get_profile
+from src.route_engine.profiles import ScoringProfile, get_profile, merge_weights
 from src.interfaces.schema.walk_schema import (
     WalkMode,
     WalkRouteStatus,
@@ -18,14 +18,16 @@ class OnewayDijkstraEngine:
         inp: OnewayRouteInput,
         G: nx.Graph,
         custom_weights: Optional[Weights] = None,
+        profile: Optional[ScoringProfile] = None,
     ):
-        self.inp          = inp
-        self.G            = G.copy()  # 원본 그래프 보호
-        self.utils        = PathUtils(self.G)
-        self.mode         = WalkMode.ONEWAY_SHORTEST
-        profile           = get_profile("default")
-        self.weights      = custom_weights or profile.weights
-        self.blocked_tags = profile.blocked_tags
+        self.inp           = inp
+        self.G             = G.copy()  # 원본 그래프 보호
+        self.utils         = PathUtils(self.G)
+        self.mode          = WalkMode.ONEWAY_SHORTEST
+        profile_config     = get_profile(profile)
+        self.weights       = merge_weights(profile_config.weights, custom_weights)
+        self.blocked_tags  = profile_config.blocked_tags
+        self.scoring_mode  = profile_config.scoring_mode
 
     def run(self) -> WalkRouteResponse:
         """
@@ -33,7 +35,7 @@ class OnewayDijkstraEngine:
         """
         # 엣지별 custom_score 기록 (in-place)
         calculate_custom_score(self.G, {
-            "mode": "general",
+            "mode": self.scoring_mode,
             "weights": self.weights,
             "blocked_tags": self.blocked_tags,
         })

--- a/src/route_engine/engines/oneway_random.py
+++ b/src/route_engine/engines/oneway_random.py
@@ -3,7 +3,7 @@ import math, random
 from typing import Optional
 
 from src.route_engine.engines.path_utils import PathUtils
-from src.route_engine.profiles import get_profile
+from src.route_engine.profiles import ScoringProfile, get_profile, merge_weights
 from src.interfaces.schema.walk_schema import (
     WalkMode,
     WalkRouteStatus,
@@ -19,14 +19,16 @@ class OnewayRandomEngine:
         inp: OnewayRouteInput,
         G: nx.Graph,
         custom_weights: Optional[Weights] = None,
+        profile: Optional[ScoringProfile] = None,
     ):
-        self.inp          = inp
-        self.G            = G.copy()  # 원본 그래프 보호
-        self.utils        = PathUtils(self.G)
-        self.mode         = WalkMode.ONEWAY_RANDOM
-        profile           = get_profile("default")
-        self.weights      = custom_weights or profile.weights
-        self.blocked_tags = profile.blocked_tags
+        self.inp           = inp
+        self.G             = G.copy()  # 원본 그래프 보호
+        self.utils         = PathUtils(self.G)
+        self.mode          = WalkMode.ONEWAY_RANDOM
+        profile_config     = get_profile(profile)
+        self.weights       = merge_weights(profile_config.weights, custom_weights)
+        self.blocked_tags  = profile_config.blocked_tags
+        self.scoring_mode  = profile_config.scoring_mode
 
     def run(self) -> WalkRouteResponse:
         """
@@ -34,7 +36,7 @@ class OnewayRandomEngine:
         """
         # 엣지별 custom_score 기록 (in-place)
         calculate_custom_score(self.G, {
-            "mode": "general",
+            "mode": self.scoring_mode,
             "weights": self.weights,
             "blocked_tags": self.blocked_tags,
         })

--- a/src/route_engine/profiles.py
+++ b/src/route_engine/profiles.py
@@ -1,30 +1,83 @@
-from typing import Union
+from enum import Enum
+from typing import Optional, Union
+
 from pydantic import BaseModel
 
-from src.interfaces.schema.walk_schema import WalkMode
 from src.schema.route_schema import Weights
+
+
+class ScoringProfile(str, Enum):
+    """
+    경로 생성 방식(WalkMode)과는 별개로, 어떤 score 조합을 선호할지 결정하는 프로필입니다.
+    WalkMode(circular_random/oneway_shortest/oneway_random)와 자유롭게 조합됩니다.
+    """
+    DEFAULT  = "default"
+    NATURE   = "nature"
+    SAFE     = "safe"
+    FLAT     = "flat"
+    RUNNING  = "running"
+    LANDMARK = "landmark"
 
 
 class ProfileConfig(BaseModel):
     weights:      Weights
     blocked_tags: list[str] = []
+    # scoring_engine.calculate_custom_score가 받는 "general" | "running" 계산 분기.
+    # running 프로필만 running_score/역방향 slope 공식을 쓰는 "running" 분기를 사용합니다.
+    scoring_mode: str = "general"
 
 
-_DEFAULT = ProfileConfig(
-    weights=Weights(safety=0.5, nature=0.5, slope=0.5),
-    blocked_tags=["underground"],
-)
-
-
-# 모드별 가중치 프로필 매핑 (현재 3개 모드 모두 기본 프로필 사용)
-PROFILES: dict[WalkMode, ProfileConfig] = {
-    WalkMode.CIRCULAR_RANDOM: _DEFAULT,
-    WalkMode.ONEWAY_SHORTEST: _DEFAULT,
-    WalkMode.ONEWAY_RANDOM:   _DEFAULT,
+PROFILES: dict[ScoringProfile, ProfileConfig] = {
+    ScoringProfile.DEFAULT: ProfileConfig(
+        weights=Weights(safety=0.5, nature=0.5, slope=0.5),
+        blocked_tags=["underground"],
+    ),
+    ScoringProfile.NATURE: ProfileConfig(
+        weights=Weights(safety=0.5, nature=0.8, slope=0.5),
+        blocked_tags=["underground"],
+    ),
+    ScoringProfile.SAFE: ProfileConfig(
+        weights=Weights(safety=0.8, nature=0.5, slope=0.5),
+        blocked_tags=["underground"],
+    ),
+    ScoringProfile.FLAT: ProfileConfig(
+        weights=Weights(safety=0.5, nature=0.5, slope=0.8),
+        blocked_tags=["underground"],
+    ),
+    ScoringProfile.RUNNING: ProfileConfig(
+        weights=Weights(safety=0.5, nature=0.5, slope=0.5, running=0.8),
+        blocked_tags=["underground"],
+        scoring_mode="running",
+    ),
+    ScoringProfile.LANDMARK: ProfileConfig(
+        weights=Weights(safety=0.5, nature=0.5, slope=0.5, landmark=0.8),
+        blocked_tags=["underground"],
+    ),
 }
+
+_DEFAULT = PROFILES[ScoringProfile.DEFAULT]
 
 
 # ── 진입점 ────────────────────────────────────────────────
 
-def get_profile(profile_name: Union[str, WalkMode]) -> ProfileConfig:
-    return PROFILES.get(profile_name, _DEFAULT)
+def get_profile(profile: Union[str, ScoringProfile, None]) -> ProfileConfig:
+    """profile/theme 이름으로 ProfileConfig를 조회합니다. 알 수 없거나 None이면 default."""
+    if profile is None:
+        return _DEFAULT
+    try:
+        key = ScoringProfile(profile)
+    except ValueError:
+        return _DEFAULT
+    return PROFILES.get(key, _DEFAULT)
+
+
+def merge_weights(base: Weights, custom_weights: Optional[Weights]) -> Weights:
+    """
+    profile.weights(base)를 기본값으로 두고, custom_weights에서 명시적으로
+    설정된 필드만 override하여 합칩니다. custom_weights가 None이면 base 그대로 반환합니다.
+    """
+    if custom_weights is None:
+        return base
+    merged = base.model_dump()
+    merged.update(custom_weights.model_dump(exclude_unset=True))
+    return Weights(**merged)

--- a/src/service/route/route_service.py
+++ b/src/service/route/route_service.py
@@ -18,6 +18,7 @@ from src.route_engine.engines import (
     OnewayRandomEngine,
 )
 from src.route_engine.engines.path_utils import PathUtils
+from src.route_engine.profiles import ScoringProfile
 from src.schema.route_schema import CircularRouteInput, OnewayRouteInput, Weights
 from src.service.user.auth_service import AuthService
 
@@ -43,10 +44,13 @@ class RouteService:
         target_km: Optional[float] = None,
         mode: WalkMode = WalkMode.CIRCULAR_RANDOM,
         custom_weights: Optional[Weights] = None,
+        profile: Optional[ScoringProfile] = None,
     ) -> WalkRouteResponse:
         """
         context에 적합한 경로 생성 엔진을 호출합니다.
-        custom_weights가 있으면 모드 프로필 대신 해당 가중치를 사용합니다.
+        mode는 경로 생성 방식(circular_random/oneway_shortest/oneway_random)을,
+        profile은 어떤 score 조합을 선호할지(scoring profile)를 결정하며 서로 독립적입니다.
+        custom_weights가 있으면 profile.weights를 base로 두고 해당 필드만 override합니다.
         """
         logger.info(
             "walk route request: mode=%s origin=(%.5f, %.5f) has_destination=%s target_km=%s",
@@ -97,7 +101,7 @@ class RouteService:
                 )
 
         try:
-            engine = self._build_engine(mode, origin, destination, target_km, custom_weights)
+            engine = self._build_engine(mode, origin, destination, target_km, custom_weights, profile)
         except ValueError:
             logger.warning("walk route invalid destination: mode=%s", mode)
             return WalkRouteResponse(
@@ -138,15 +142,16 @@ class RouteService:
         destination: Optional[Coordinate] = None,
         target_km: Optional[float] = None,
         custom_weights: Optional[Weights] = None,
+        profile: Optional[ScoringProfile] = None,
     ):
-        """custom_weights를 엔진에 주입해 경로 생성 엔진 인스턴스를 반환합니다."""
+        """profile/custom_weights를 엔진에 주입해 경로 생성 엔진 인스턴스를 반환합니다."""
         if mode == WalkMode.CIRCULAR_RANDOM:
             inp = CircularRouteInput(
                 start_lat=origin.lat,
                 start_lon=origin.lon,
                 target_km=target_km,
             )
-            return self.base_engines[mode](inp, self.G, custom_weights=custom_weights)
+            return self.base_engines[mode](inp, self.G, custom_weights=custom_weights, profile=profile)
 
         if destination is None:
             raise ValueError(f"{mode} 모드에서는 destination이 필요합니다")
@@ -158,4 +163,4 @@ class RouteService:
             end_lon=destination.lon,
             target_km=target_km,
         )
-        return self.base_engines[mode](inp, self.G, custom_weights=custom_weights)
+        return self.base_engines[mode](inp, self.G, custom_weights=custom_weights, profile=profile)

--- a/tests/unit/test_scoring_engine_regression.py
+++ b/tests/unit/test_scoring_engine_regression.py
@@ -20,8 +20,7 @@ scoring_engine.calculate_custom_score의 "현재 동작"을 고정하는 회귀 
 import networkx as nx
 
 from src.route_engine.scoring.scoring_engine import calculate_custom_score
-from src.route_engine.profiles import PROFILES, ProfileConfig
-from src.interfaces.schema.walk_schema import WalkMode
+from src.route_engine.profiles import PROFILES, ProfileConfig, ScoringProfile
 from src.schema.route_schema import Weights
 
 # ── 그래프 헬퍼 ──────────────────────────────────────────────────────────────
@@ -64,7 +63,7 @@ _CHILD    = ProfileConfig(weights=Weights(safety=1.0, nature=0.3, slope=1.0, chi
 _LANDMARK = ProfileConfig(weights=Weights(safety=0.5, nature=0.5, slope=0.3, landmark=1.0), blocked_tags=["underground"])
 _RUNNING  = ProfileConfig(weights=Weights(safety=0.5, nature=0.5, slope=0.7, running=1.0),  blocked_tags=["underground"])
 
-DEFAULT_PROFILE  = profile_payload(PROFILES[WalkMode.CIRCULAR_RANDOM], mode="general")
+DEFAULT_PROFILE  = profile_payload(PROFILES[ScoringProfile.DEFAULT], mode="general")
 CHILD_PROFILE    = profile_payload(_CHILD,    mode="general")
 LANDMARK_PROFILE = profile_payload(_LANDMARK, mode="general")
 RUNNING_PROFILE  = profile_payload(_RUNNING,  mode="running")


### PR DESCRIPTION
## ☝️Issue Number
- resolve #207 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)

WalkMode와 scoring profile 분리 작업 완료했습니다.

- WalkMode는 경로 생성 방식(circular_random / oneway_shortest / oneway_random)만 담당하도록 유지했습니다.
- ScoringProfile(default / nature / safe / flat / running / landmark)을 별도로 분리했습니다.
- profiles.py가 WalkMode 기준이 아니라 ScoringProfile 기준으로 동작하도록 수정했습니다.
- route_service / route_tools / walk_router에서 profile을 전달할 수 있도록 수정했습니다.
- custom_weights는 profile 기본 weights를 기준으로, 명시된 값만 override하는 방식으로 병합되도록 했습니다.
- scoring_engine 공식 자체는 변경하지 않았습니다.

테스트:
관련 테스트 67개 통과했습니다.
전체 테스트 중 auth/banner/prewalk 쪽 실패는 기존 이슈로 확인했습니다.

다음 작업 예상:
- 각 score가 어떤 데이터 근거에서 계산되는지 catalog 문서화
- 현재 src/data/raw에 있는 데이터들이 어떤 score에 연결되는지 정리
- approved registry 데이터만 실제 ingest 대상이 되도록 연결
- street_tree 등 raw 데이터를 시범으로 DB/layer/score에 반영
- 반영 후 profile별 경로 결과가 실제로 달라지는지 테스트