### PR TITLE
[Feat] 온보딩 설문 UI 구현 및 app.py 연결, 사이드바 선호도 패널 추가

### DIFF
--- a/frontend/streamlit_prototype/api/survey_router.py
+++ b/frontend/streamlit_prototype/api/survey_router.py
@@ -1,0 +1,34 @@
+"""
+frontend/streamlit_prototype/api/survey_router.py
+
+온보딩 설문 관련 백엔드 API 호출 클라이언트.
+"""
+import httpx
+from frontend.streamlit_prototype.api.base_url import base_url
+
+
+class SurveyRouter:
+    """설문 제출 및 완료 여부 조회 API 클라이언트."""
+
+    def __init__(self):
+        self.base_url = f"{base_url}/api/user"
+
+    async def get_status(self, access_token: str) -> dict:
+        """GET /api/user/survey — 설문 완료 여부를 조회합니다."""
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            cookies = {"access_token": access_token} if access_token else {}
+            response = await client.get(f"{self.base_url}/survey", cookies=cookies)
+            if response.status_code != 200:
+                return {"survey_completed": False}
+            return response.json()
+
+    async def submit(self, access_token: str, tags: list[str], distance: str | None) -> dict:
+        """POST /api/user/survey — 설문 결과를 제출합니다."""
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            cookies = {"access_token": access_token} if access_token else {}
+            response = await client.post(
+                f"{self.base_url}/survey",
+                json={"tags": tags, "distance": distance},
+                cookies=cookies,
+            )
+            return response.json()

--- a/frontend/streamlit_prototype/app.py
+++ b/frontend/streamlit_prototype/app.py
@@ -16,6 +16,7 @@ from frontend.streamlit_prototype.sections.header import render_header
 from frontend.streamlit_prototype.sections.sidebar import render_sidebar, apply_input_mode
 from frontend.streamlit_prototype.sections.map_section import render_map
 from frontend.streamlit_prototype.sections.result_section import render_result
+from frontend.streamlit_prototype.sections.survey import require_survey
 
 class App:    
     def __init__(self):
@@ -24,11 +25,14 @@ class App:
 
     def run(self) -> None:
         # 앱의 전체 렌더링 흐름을 섹션 순서대로 실행
-        ctx           = self._ctx
+        ctx = self._ctx
         setup_page(ctx.walk_route_map)
 
         # 로그인 게이트: 미로그인 시 로그인 UI만 렌더링하고 중단
         if not require_login():
+            return
+        
+        if not require_survey():
             return
 
         lat, lng, env = render_header(ctx)

--- a/frontend/streamlit_prototype/sections/sidebar.py
+++ b/frontend/streamlit_prototype/sections/sidebar.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from frontend.streamlit_prototype.api.health_router import HealthRouter
 from frontend.streamlit_prototype.modes.base import BaseRouteMode, RouteParams
 from frontend.streamlit_prototype.modes.registry import ROUTE_MODES
+from frontend.streamlit_prototype.api.survey_router import SurveyRouter
+import asyncio
 
 
 @dataclass
@@ -43,6 +45,40 @@ def _render_params(mode: BaseRouteMode) -> RouteParams:
     return mode.render_params()
 
 
+def _render_preference_panel():
+    """사이드바에 현재 사용자 가중치를 표시합니다."""
+    access_token = st.session_state.get("access_token", "")
+    if not access_token:
+        return
+
+    try:
+        loop = asyncio.new_event_loop()
+        result = loop.run_until_complete(SurveyRouter().get_status(access_token))
+    except Exception:
+        return
+
+    if not result.get("survey_completed"):
+        return
+
+    LABEL_MAP = {
+        "weights_safety":   "안전",
+        "weights_nature":   "자연",
+        "weights_slope":    "평지",
+        "weights_running":  "러닝",
+        "weights_landmark": "볼거리",
+        "weights_child":    "어린이",
+    }
+
+    with st.sidebar.expander("내 선호도", expanded=False):
+        km = result.get("default_target_km")
+        if km:
+            st.caption(f"기본 거리: {km}km")
+        for key, label in LABEL_MAP.items():
+            val = result.get(key)
+            if val is not None:
+                st.progress(val, text=f"{label}: {val:.2f}")
+
+
 def render_sidebar() -> SidebarConfig:
     """
     input : X
@@ -53,6 +89,9 @@ def render_sidebar() -> SidebarConfig:
     db_ok = HealthRouter().get_health()
     st.sidebar.markdown("### 시스템 상태")
     st.sidebar.success("🟢 DB 연결됨") if db_ok else st.sidebar.error("🔴 DB 연결 실패")
+
+    _render_preference_panel()
+    
     st.sidebar.markdown("### 경로 설정")
 
     input_mode = st.sidebar.radio("입력 방식", ["직접 설정", "AI 챗봇"])

--- a/frontend/streamlit_prototype/sections/survey.py
+++ b/frontend/streamlit_prototype/sections/survey.py
@@ -1,0 +1,99 @@
+"""
+frontend/streamlit_prototype/sections/survey.py
+
+온보딩 설문 UI. 로그인 직후 survey_completed = False인 사용자에게 노출.
+SURVEY_TAGS 키워드 선택 + 선호 거리 선택 후 제출하면 UserPreference에 저장된다.
+"""
+import asyncio
+import streamlit as st
+
+from frontend.streamlit_prototype.api.survey_router import SurveyRouter
+from src.service.user.survey_service import SURVEY_TAGS
+
+
+def _run_async(coro):
+    """비동기 코루틴을 동기 컨텍스트에서 실행합니다."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)
+
+
+def require_survey() -> bool:
+    """
+    설문 완료 여부를 확인하고, 미완료 시 설문 UI를 렌더링합니다.
+    완료 or 스킵 시 True, 설문 진행 중이면 False를 반환합니다.
+    """
+    # 이미 완료된 경우
+    if st.session_state.get("survey_completed"):
+        return True
+
+    # API로 완료 여부 확인 (1회)
+    if "survey_status_checked" not in st.session_state:
+        st.session_state["survey_status_checked"] = True
+        router = SurveyRouter()
+        result = _run_async(router.get_status(st.session_state.get("access_token", "")))
+        if result.get("survey_completed"):
+            st.session_state["survey_completed"] = True
+            return True
+
+    # 설문 UI 렌더링
+    _render_survey()
+    return False
+
+
+def _render_survey():
+    """설문 태그 선택 및 제출 UI를 렌더링합니다."""
+    st.markdown("## 🌿 어떤 산책을 좋아하세요?")
+    st.markdown("마음에 드는 키워드를 골라주세요! (여러 개 선택 가능)")
+
+    # 태그 선택 (session_state로 선택 상태 유지)
+    if "selected_tags" not in st.session_state:
+        st.session_state["selected_tags"] = []
+
+    cols = st.columns(3)
+    for i, tag in enumerate(SURVEY_TAGS):
+        with cols[i % 3]:
+            selected = tag in st.session_state["selected_tags"]
+            label = f"✅ {tag}" if selected else tag
+            if st.button(label, key=f"tag_{tag}"):
+                if selected:
+                    st.session_state["selected_tags"].remove(tag)
+                else:
+                    st.session_state["selected_tags"].append(tag)
+                st.rerun()
+
+    st.markdown("---")
+    st.markdown("**평소 산책 거리는 어느 정도인가요?**")
+    distance_label = st.radio(
+        "",
+        ["~2km (가볍게)", "2~4km (적당히)", "4km+ (활발하게)"],
+        index=1,
+        horizontal=True,
+        label_visibility="collapsed",
+    )
+    distance_map = {
+        "~2km (가볍게)": "slow",
+        "2~4km (적당히)": "normal",
+        "4km+ (활발하게)": "fast",
+    }
+    distance = distance_map[distance_label]
+
+    col1, col2 = st.columns([1, 1])
+    with col1:
+        if st.button("완료", type="primary", use_container_width=True):
+            router = SurveyRouter()
+            _run_async(router.submit(
+                st.session_state.get("access_token", ""),
+                st.session_state["selected_tags"],
+                distance,
+            ))
+            st.session_state["survey_completed"] = True
+            st.session_state["selected_tags"] = []
+            st.rerun()
+    with col2:
+        if st.button("나중에 하기", use_container_width=True):
+            st.session_state["survey_completed"] = True
+            st.rerun()

--- a/src/interfaces/api/user_router.py
+++ b/src/interfaces/api/user_router.py
@@ -8,7 +8,7 @@ src/interfaces/api/user_router.py
 from fastapi import APIRouter, Cookie, Depends, HTTPException
 
 from src.interfaces.dependencies import get_survey_service, get_auth_service, get_user_service
-from src.interfaces.schema.survey_schema import SurveyRequest, SurveyResponse
+from src.interfaces.schema.survey_schema import SurveyRequest, SurveyResponse, SurveyStatusResponse
 from src.interfaces.schema.user_schema import (
     UserMeResponse, UserUpdateRequest, UserUpdateResponse,
     RouteHistoryResponse, RouteHistoryItem,
@@ -145,3 +145,12 @@ def get_route_history(
     except Exception as e:
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/survey", response_model=SurveyStatusResponse)
+def get_survey_status(
+    access_token: str = Cookie(None),
+    service: SurveyService = Depends(get_survey_service),
+):
+    """설문 완료 여부를 반환합니다."""
+    return service.get_status(access_token)

--- a/src/interfaces/schema/survey_schema.py
+++ b/src/interfaces/schema/survey_schema.py
@@ -51,3 +51,14 @@ class SurveyResponse(BaseModel):
     weights_running: Optional[float] = None
     weights_landmark: Optional[float] = None
     weights_child: Optional[float] = None
+    
+class SurveyStatusResponse(BaseModel):
+    """설문 완료 여부 및 저장된 가중치 조회 응답 스키마입니다."""
+    survey_completed: bool
+    default_target_km: Optional[float] = None
+    weights_safety: Optional[float] = None
+    weights_nature: Optional[float] = None
+    weights_slope: Optional[float] = None
+    weights_running: Optional[float] = None
+    weights_landmark: Optional[float] = None
+    weights_child: Optional[float] = None

--- a/src/service/user/survey_service.py
+++ b/src/service/user/survey_service.py
@@ -5,10 +5,11 @@ src/service/user/survey_service.py
 키워드 태그를 경로 가중치로 변환하고 UserPreference에 저장한다.
 """
 from src.interfaces.schema.auth_schema import Status
-from src.interfaces.schema.survey_schema import DistanceOption, SurveyRequest, SurveyResponse, SurveyStatus
 from src.repository.user.user_preference_repository import UserPreferenceRepository
 from src.repository.user.user_repository import UserRepository
 from src.service.user.auth_service import AuthService
+from src.interfaces.schema.survey_schema import DistanceOption, SurveyRequest, SurveyResponse, SurveyStatus, SurveyStatusResponse
+
 
 TAG_WEIGHT_MAP: dict[str, dict[str, float]] = {
     # nature: 자연 친화도
@@ -121,6 +122,31 @@ class SurveyService:
 
         return SurveyResponse(
             status=SurveyStatus.SUCCESS,
+            default_target_km=preference.default_target_km,
+            weights_safety=preference.weights_safety,
+            weights_nature=preference.weights_nature,
+            weights_slope=preference.weights_slope,
+            weights_running=preference.weights_running,
+            weights_landmark=preference.weights_landmark,
+            weights_child=preference.weights_child,
+        )
+    
+    def get_status(self, access_token: str | None) -> SurveyStatusResponse:
+        """사용자의 설문 완료 여부와 저장된 가중치를 반환합니다."""
+        status, provider, provider_id = self.auth_service.check_access_token(access_token)
+        if status != Status.SUCCESS:
+            return SurveyStatusResponse(survey_completed=False)
+
+        user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)
+        if user is None:
+            return SurveyStatusResponse(survey_completed=False)
+
+        preference = UserPreferenceRepository.get_by_user_id(user.id)
+        if preference is None or not preference.survey_completed:
+            return SurveyStatusResponse(survey_completed=False)
+
+        return SurveyStatusResponse(
+            survey_completed=True,
             default_target_km=preference.default_target_km,
             weights_safety=preference.weights_safety,
             weights_nature=preference.weights_nature,


### PR DESCRIPTION
## ☝️Issue Number
- resolve #203 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 온보딩 설문 UI 구현 및 app.py 연결 (로그인 후 설문 미완료 사용자에게 태그 선택 화면 노출)
- 사이드바 선호도 패널 추가 (설문 완료 사용자의 가중치 시각화)
- `GET /api/user/survey` 엔드포인트 추가 (설문 완료 여부 및 저장된 가중치 반환)