### PR TITLE
[feat] map 엔드포인트 및 응답 스키마 추가

### DIFF
--- a/src/interfaces/api/map_router.py
+++ b/src/interfaces/api/map_router.py
@@ -11,6 +11,12 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Depends
 
 from src.interfaces.dependencies import get_map_service
+from src.interfaces.schema.map_schema import (
+    FacilityResponse,
+    PointResponse,
+    LandmarkResponse,
+    EdgeResponse,
+)
 from src.service import MapService
 
 router = APIRouter(
@@ -19,7 +25,7 @@ router = APIRouter(
 )
 
 
-@router.get("/facilities")
+@router.get("/facilities", response_model=list[FacilityResponse])
 async def get_facilities(
     lat: float,
     lon: float,
@@ -47,7 +53,7 @@ async def get_facilities(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/points/safety")
+@router.get("/points/safety", response_model=list[PointResponse])
 def get_safety_points(
     lat: float,
     lon: float,
@@ -69,7 +75,7 @@ def get_safety_points(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/points/nature")
+@router.get("/points/nature", response_model=list[PointResponse])
 def get_nature_points(
     lat: float,
     lon: float,
@@ -91,7 +97,7 @@ def get_nature_points(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/points/landmark")
+@router.get("/points/landmark", response_model=list[LandmarkResponse])
 def get_landmark_points(
     lat: float,
     lon: float,
@@ -112,7 +118,7 @@ def get_landmark_points(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/points/child")
+@router.get("/points/child", response_model=list[PointResponse])
 def get_child_points(
     lat: float,
     lon: float,
@@ -134,7 +140,7 @@ def get_child_points(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/points/running")
+@router.get("/points/running", response_model=list[PointResponse])
 def get_running_points(
     lat: float,
     lon: float,
@@ -156,7 +162,7 @@ def get_running_points(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/edges")
+@router.get("/edges", response_model=list[EdgeResponse])
 def get_edges(
     lat: float,
     lon: float,

--- a/src/interfaces/schema/map_schema.py
+++ b/src/interfaces/schema/map_schema.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+
+
+class FacilityResponse(BaseModel):
+    name: str
+    lon: float
+    lat: float
+    address: str
+
+
+class PointResponse(BaseModel):
+    lat: float
+    lon: float
+    category: str
+
+
+class LandmarkResponse(BaseModel):
+    lat: float
+    lon: float
+
+
+class EdgeResponse(BaseModel):
+    path: list[list[float]]
+    link_id: str


### PR DESCRIPTION
## Summary
- `src/interfaces/schema/map_schema.py` 생성: map 관련 Pydantic 응답 스키마 정의 (FacilityResponse, PointResponse, LandmarkResponse, EdgeResponse)
- `src/interfaces/api/map_router.py` 수정: 7개 엔드포인트에 response_model 적용

## Test plan
- [ ] /docs에서 각 엔드포인트 응답 스키마 확인
- [ ] /api/map/points/*, /api/map/edges 200 OK 응답 확인
