### PR TITLE
Feat: 챗봇 예외처리 end-to-end 반영

### DIFF
--- a/src/agent/nodes/extractor.py
+++ b/src/agent/nodes/extractor.py
@@ -31,11 +31,15 @@ class Extractor(GPTClient):
         }
 
         # extractor 응답 생성
-        res = await super().get_response(
-            prompt_name     = "extraction",
-            input_variables = input_variables,
-            llm             = self.model,
-        )
+        try:
+            res = await super().get_response(
+                prompt_name     = "extraction",
+                input_variables = input_variables,
+                llm             = self.model,
+            )
+        except Exception:
+            logger.exception("extractor_llm_error")
+            return state
 
         # 예외1. 산책 모드를 결정하지 못한 경우
         if not res or not res.tool_calls:
@@ -80,12 +84,12 @@ class Extractor(GPTClient):
         from src.service.user.survey_service import TAG_WEIGHT_MAP  # 순환 import 방지(지연 로드)
 
         tag_keys = list(TAG_WEIGHT_MAP.keys())
-        res = await super().get_response(
-            prompt_name     = "themes",
-            input_variables = {"user_input": user_input, "tag_keys": tag_keys},
-            parser          = self.str_parser,
-        )
         try:
+            res = await super().get_response(
+                prompt_name     = "themes",
+                input_variables = {"user_input": user_input, "tag_keys": tag_keys},
+                parser          = self.str_parser,
+            )
             tags = json.loads(res)
             return [t for t in tags if t in TAG_WEIGHT_MAP]
         except Exception:

--- a/src/agent/nodes/interviewer.py
+++ b/src/agent/nodes/interviewer.py
@@ -44,21 +44,32 @@ class Interviewer(GPTClient):
             "user_input":       state.user_prompt,
         }
 
+        _FALLBACK_RESPONSE = "죄송해요, 일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요."
+
         # 정보가 충분하다면 -> 경로 생성 시작을 알리는 메시지 제공
         if is_complete:
-            response = await super().get_response(
-                prompt_name     = "complete",
-                input_variables = input_variables,
-                parser          = self.str_parser,
-            )
+            try:
+                response = await super().get_response(
+                    prompt_name     = "complete",
+                    input_variables = input_variables,
+                    parser          = self.str_parser,
+                )
+            except Exception:
+                logger.exception("interviewer_complete_llm_error")
+                response = _FALLBACK_RESPONSE
             logger.info("complete.yaml이 호출되었습니다.")
         # 정보가 부족하다면 -> 질문
         else:
-            raw_response = await super().get_response(
-                prompt_name="interview",
-                input_variables=input_variables,
-                llm=self.model,
-            )
+            try:
+                raw_response = await super().get_response(
+                    prompt_name="interview",
+                    input_variables=input_variables,
+                    llm=self.model,
+                )
+            except Exception:
+                logger.exception("interviewer_interview_llm_error")
+                state.response = _FALLBACK_RESPONSE
+                return state
             logger.info("interview.yaml이 호출되었습니다.")
 
             candidates = await self._execute_tool_calls(
@@ -86,22 +97,30 @@ class Interviewer(GPTClient):
 
                 if is_complete:
                     input_variables["current_context"] = self.prompt_utils.format_for_prompt(state.user_context)
-                    response = await super().get_response(
-                        prompt_name="complete",
-                        input_variables=input_variables,
-                        parser=self.str_parser,
-                    )
+                    try:
+                        response = await super().get_response(
+                            prompt_name="complete",
+                            input_variables=input_variables,
+                            parser=self.str_parser,
+                        )
+                    except Exception:
+                        logger.exception("interviewer_complete_llm_error")
+                        response = _FALLBACK_RESPONSE
                     logger.info("complete.yaml이 호출되었습니다.")
                 else:
-                    response = await super().get_response(
-                        prompt_name="location_formatter",
-                        input_variables={
-                            "tool_calls":       self.prompt_utils.format_for_prompt(candidates),
-                            "user_input":       state.user_prompt,
-                            "current_location": self.prompt_utils.format_for_prompt(state.current_location),
-                        },
-                        parser=self.str_parser,
-                    )
+                    try:
+                        response = await super().get_response(
+                            prompt_name="location_formatter",
+                            input_variables={
+                                "tool_calls":       self.prompt_utils.format_for_prompt(candidates),
+                                "user_input":       state.user_prompt,
+                                "current_location": self.prompt_utils.format_for_prompt(state.current_location),
+                            },
+                            parser=self.str_parser,
+                        )
+                    except Exception:
+                        logger.exception("interviewer_location_formatter_llm_error")
+                        response = _FALLBACK_RESPONSE
                     logger.info("location_formatter.yaml이 호출되었습니다.")
             else:
                 response = raw_response.content

--- a/src/agent/nodes/weather_checker.py
+++ b/src/agent/nodes/weather_checker.py
@@ -1,8 +1,12 @@
+import logging
+
 from langchain_core.output_parsers import StrOutputParser
 
 from src.infrastructure.external.client.gpt_client import GPTClient
 from src.infrastructure.external.client.weather_client import WeatherClient
 from src.infrastructure.external.schema.weather_schema import EnvironmentInfo
+
+logger = logging.getLogger(__name__)
 
 
 class WeatherChecker(GPTClient):
@@ -15,16 +19,29 @@ class WeatherChecker(GPTClient):
         """
         날씨·대기질 조회 후 LLM으로 친절한 첫 인사 메시지를 생성하여 반환합니다.
         """
-        weather_info = await self.weather_client.get_weather(lat, lon)
-        air_info     = await self.weather_client.get_air_quality(lat, lon)
+        try:
+            weather_info = await self.weather_client.get_weather(lat, lon)
+        except Exception:
+            logger.exception("weather_api_error | lat=%s | lon=%s", lat, lon)
+            weather_info = None
 
-        res = await self.get_response(
-            prompt_name="weather_checker",
-            input_variables={
-                "weather_info": str(weather_info),
-                "air_info":     str(air_info),
-            },
-            parser=self.str_parser
-        )
+        try:
+            air_info = await self.weather_client.get_air_quality(lat, lon)
+        except Exception:
+            logger.exception("air_quality_api_error | lat=%s | lon=%s", lat, lon)
+            air_info = None
+
+        try:
+            res = await self.get_response(
+                prompt_name="weather_checker",
+                input_variables={
+                    "weather_info": str(weather_info),
+                    "air_info":     str(air_info),
+                },
+                parser=self.str_parser
+            )
+        except Exception:
+            logger.exception("weather_checker_llm_error | lat=%s | lon=%s", lat, lon)
+            res = "안녕하세요! 오늘 어디로 산책을 떠나볼까요?"
 
         return EnvironmentInfo(weather=weather_info or {}, air=air_info or {}), res

--- a/src/interfaces/api/prewalk_router.py
+++ b/src/interfaces/api/prewalk_router.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Cookie
 from src.database.postgresql import get_postgresql_db
 from src.interfaces.schema.prewalk_schema import InitRequest, ChatRequest, ChatResponse
@@ -6,6 +8,8 @@ from src.interfaces.validators.highway_validator import validate_no_highway
 from src.interfaces.validators.water_validator import snap_coordinate_from_water
 from src.service.chat.prewalk_service import PrewalkOrchestrator
 from src.interfaces.dependencies import get_prewalk_orchestrator
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/api/prewalk",
@@ -39,6 +43,9 @@ async def read_init_message(
         raise
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception("prewalk_init_unexpected_error | lat=%s | lon=%s", request.lat, request.lon)
+        raise HTTPException(status_code=500, detail=str(e))
 
 @router.post("/intent", response_model=ChatResponse)
 async def read_message(
@@ -49,4 +56,10 @@ async def read_message(
     """
     사용자가 메시지를 보낼 때마다 호출됩니다.
     """
-    return await service.orchestrator(access_token, request.thread_id, request.user_prompt)
+    try:
+        return await service.orchestrator(access_token, request.thread_id, request.user_prompt)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("prewalk_intent_unexpected_error | thread_id=%s", request.thread_id)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/interfaces/schema/prewalk_schema.py
+++ b/src/interfaces/schema/prewalk_schema.py
@@ -43,6 +43,13 @@ class ChatRequest(BaseModel):
     thread_id: str
     user_prompt: str
 
+    @field_validator("user_prompt")
+    @classmethod
+    def check_not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("user_prompt는 공백일 수 없습니다.")
+        return v
+
 
 class ChatStatus(str, Enum):
     SUCCESS = "success"
@@ -50,6 +57,7 @@ class ChatStatus(str, Enum):
     INVALID_TOKEN = "invalid_token"
     SESSION_NOT_FOUND = "session_not_found"
     UNACCESSIBLE = "unaccessible"
+    INTERNAL_ERROR = "internal_error"
 
 
 class ChatResponse(BaseModel):

--- a/src/service/chat/prewalk_service.py
+++ b/src/service/chat/prewalk_service.py
@@ -1,3 +1,4 @@
+import logging
 from uuid import uuid4
 
 from langgraph.graph import StateGraph, END
@@ -15,6 +16,8 @@ from src.agent.nodes import (
 from src.interfaces.schema.prewalk_schema import ChatResponse, ChatStatus
 from src.schema.prewalk_schema import State, Location
 from src.service.user.auth_service import AuthService
+
+logger = logging.getLogger(__name__)
 
 
 class PrewalkOrchestrator:
@@ -64,32 +67,52 @@ class PrewalkOrchestrator:
         status, provider, provider_id = self.auth_service.check_access_token(access_token)
         if status != ChatStatus.SUCCESS:
             return ChatResponse(status=status, thread_id=None, state=None)
-        
-        user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)
 
-        # 챗봇 스레드 생성
-        thread_id = str(uuid4())
-        ChatSessionRepository.save(user.id, thread_id)
+        try:
+            user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)
+        except Exception:
+            logger.exception("prewalk_init_user_lookup_error | provider=%s", provider)
+            return ChatResponse(status=ChatStatus.INTERNAL_ERROR, thread_id=None, state=None)
 
-        # 날씨 확인
-        env_info, init_message = await self.weather_checker.run(lat, lon)
+        try:
+            thread_id = str(uuid4())
+            ChatSessionRepository.save(user.id, thread_id)
+        except Exception:
+            logger.exception("prewalk_init_session_save_error | user_id=%s", user.id)
+            return ChatResponse(status=ChatStatus.INTERNAL_ERROR, thread_id=None, state=None)
 
-        # 현재 위치 확인
-        current_location = await self.kakao_client.get_address_from_coords(lat, lon)
+        # 날씨 확인 — 실패 시 기본 인사 메시지로 대체
+        try:
+            env_info, init_message = await self.weather_checker.run(lat, lon)
+        except Exception:
+            logger.exception("prewalk_init_weather_error | lat=%s | lon=%s", lat, lon)
+            env_info     = None
+            init_message = "안녕하세요! 오늘 어디로 산책을 떠나볼까요?"
 
-        initial_state = State(
-            user_id = user.id,
-            current_location  = Location(
+        # 현재 위치 확인 — 실패 시 좌표만으로 Location 구성
+        try:
+            kakao_result = await self.kakao_client.get_address_from_coords(lat, lon)
+            location = Location(
                 lat        = lat,
                 lon        = lon,
-                address    = current_location.place_address,
-                place_name = current_location.place_name,
-            ),
-            weather_data = env_info,
-            response     = init_message
+                address    = kakao_result.place_address,
+                place_name = kakao_result.place_name,
+            )
+        except Exception:
+            logger.exception("prewalk_init_kakao_error | lat=%s | lon=%s", lat, lon)
+            location = Location(lat=lat, lon=lon)
+
+        initial_state = State(
+            user_id          = user.id,
+            current_location = location,
+            weather_data     = env_info,
+            response         = init_message,
         )
 
-        await ChatStateRepository.save_state(thread_id=thread_id, state=initial_state)
+        try:
+            await ChatStateRepository.save_state(thread_id=thread_id, state=initial_state)
+        except Exception:
+            logger.exception("prewalk_init_state_save_error | thread_id=%s", thread_id)
 
         return ChatResponse(status=status, thread_id=thread_id, state=initial_state)
 
@@ -101,25 +124,43 @@ class PrewalkOrchestrator:
         status, provider, provider_id = self.auth_service.check_access_token(access_token)
         if status != ChatStatus.SUCCESS:
             return ChatResponse(status=status, thread_id=None, state=None)
-        
+
         # 챗봇 최근 대화 내역 조회
-        state = await ChatStateRepository.get_state(thread_id)
+        try:
+            state = await ChatStateRepository.get_state(thread_id)
+        except Exception:
+            logger.exception("prewalk_intent_state_load_error | thread_id=%s", thread_id)
+            return ChatResponse(status=ChatStatus.INTERNAL_ERROR, thread_id=None, state=None)
+
         if not state:
             return ChatResponse(status=ChatStatus.SESSION_NOT_FOUND, thread_id=None, state=None)
 
         # 사용자의 접근 권한 확인
-        user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)
+        try:
+            user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)
+        except Exception:
+            logger.exception("prewalk_intent_user_lookup_error | provider=%s", provider)
+            return ChatResponse(status=ChatStatus.INTERNAL_ERROR, thread_id=None, state=None)
+
         if state.user_id != user.id:
             return ChatResponse(status=ChatStatus.UNACCESSIBLE, thread_id=None, state=None)
-        
+
         # 최근 프롬프트로 업데이트
-        state.user_prompt = user_prompt
+        state.user_prompt  = user_prompt
         state.access_token = access_token
 
         # state 업데이트
-        result      = await self.graph.ainvoke(state)
-        final_state = State.model_validate(result)
-        await ChatStateRepository.save_state(thread_id, final_state)
+        try:
+            result      = await self.graph.ainvoke(state)
+            final_state = State.model_validate(result)
+        except Exception:
+            logger.exception("prewalk_intent_graph_error | thread_id=%s", thread_id)
+            return ChatResponse(status=ChatStatus.INTERNAL_ERROR, thread_id=None, state=None)
+
+        try:
+            await ChatStateRepository.save_state(thread_id, final_state)
+        except Exception:
+            logger.exception("prewalk_intent_state_save_error | thread_id=%s", thread_id)
 
         return ChatResponse(
             status    = status,

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -288,37 +288,45 @@ class TestAuthCheckRefreshToken:
 
 class TestPrewalkInitAPI:
     def test_초기_메시지_요청_성공(self, client):
-        from src.schema.prewalk_schema import State
+        from src.interfaces.schema.prewalk_schema import ChatResponse, ChatStatus
+        from src.schema.prewalk_schema import State, Location
 
         mock_orchestrator = MagicMock()
         mock_orchestrator.get_init_message = AsyncMock(
-            return_value={
-                "thread_id": "thread-abc-123",
-                "state": State(
-                    user_uuid="user-uuid-001",
-                    current_location={"lat": 37.5, "lon": 127.0},
+            return_value=ChatResponse(
+                status=ChatStatus.SUCCESS,
+                thread_id="thread-abc-123",
+                state=State(
+                    user_id=1,
+                    current_location=Location(lat=37.5, lon=127.0),
                 ),
-            }
+            )
         )
-        with patch(
-            "src.interfaces.dependencies.prewalk_orchestrator", mock_orchestrator
-        ):
+        with patch("src.interfaces.dependencies.prewalk_orchestrator", mock_orchestrator):
             response = client.post(
                 "/api/prewalk/init",
-                json={
-                    "user_uuid": "user-uuid-001",
-                    "lat": 37.5,
-                    "lon": 127.0,
-                },
+                json={"lat": 37.5, "lon": 127.0},
             )
         assert response.status_code == 200
         body = response.json()
-        assert "thread_id" in body
+        assert body["status"] == "success"
         assert body["thread_id"] == "thread-abc-123"
 
     def test_필수_필드_누락_시_422_반환(self, client):
-        response = client.post("/api/prewalk/init", json={"user_uuid": "user-uuid-001"})
+        response = client.post("/api/prewalk/init", json={})
         assert response.status_code == 422
+
+    def test_서비스_내부_오류_시_500_반환(self, client):
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.get_init_message = AsyncMock(
+            side_effect=RuntimeError("DB 연결 실패")
+        )
+        with patch("src.interfaces.dependencies.prewalk_orchestrator", mock_orchestrator):
+            response = client.post(
+                "/api/prewalk/init",
+                json={"lat": 37.5, "lon": 127.0},
+            )
+        assert response.status_code == 500
 
 
 # ── POST /api/prewalk/intent ─────────────────────────────────────────────────
@@ -326,21 +334,21 @@ class TestPrewalkInitAPI:
 
 class TestPrewalkIntentAPI:
     def test_챗봇_대화_요청_성공(self, client):
-        from src.schema.prewalk_schema import State
+        from src.interfaces.schema.prewalk_schema import ChatResponse, ChatStatus
+        from src.schema.prewalk_schema import State, Location
 
         mock_orchestrator = MagicMock()
         mock_orchestrator.orchestrator = AsyncMock(
-            return_value={
-                "thread_id": "thread-abc-123",
-                "state": State(
-                    user_uuid="user-uuid-001",
-                    current_location={"lat": 37.5, "lon": 127.0},
+            return_value=ChatResponse(
+                status=ChatStatus.SUCCESS,
+                thread_id="thread-abc-123",
+                state=State(
+                    user_id=1,
+                    current_location=Location(lat=37.5, lon=127.0),
                 ),
-            }
+            )
         )
-        with patch(
-            "src.interfaces.dependencies.prewalk_orchestrator", mock_orchestrator
-        ):
+        with patch("src.interfaces.dependencies.prewalk_orchestrator", mock_orchestrator):
             response = client.post(
                 "/api/prewalk/intent",
                 json={
@@ -349,6 +357,7 @@ class TestPrewalkIntentAPI:
                 },
             )
         assert response.status_code == 200
+        assert response.json()["status"] == "success"
         assert response.json()["thread_id"] == "thread-abc-123"
 
     def test_필수_필드_누락_시_422_반환(self, client):
@@ -356,6 +365,40 @@ class TestPrewalkIntentAPI:
             "/api/prewalk/intent", json={"thread_id": "thread-abc-123"}
         )
         assert response.status_code == 422
+
+    def test_공백_user_prompt_시_422_반환(self, client):
+        response = client.post(
+            "/api/prewalk/intent",
+            json={"thread_id": "thread-abc-123", "user_prompt": "   "},
+        )
+        assert response.status_code == 422
+
+    def test_존재하지_않는_thread_id_시_session_not_found_반환(self, client):
+        from src.interfaces.schema.prewalk_schema import ChatResponse, ChatStatus
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.orchestrator = AsyncMock(
+            return_value=ChatResponse(status=ChatStatus.SESSION_NOT_FOUND, thread_id=None, state=None)
+        )
+        with patch("src.interfaces.dependencies.prewalk_orchestrator", mock_orchestrator):
+            response = client.post(
+                "/api/prewalk/intent",
+                json={"thread_id": "invalid-thread", "user_prompt": "산책 추천해줘"},
+            )
+        assert response.status_code == 200
+        assert response.json()["status"] == "session_not_found"
+
+    def test_서비스_내부_오류_시_500_반환(self, client):
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.orchestrator = AsyncMock(
+            side_effect=RuntimeError("LLM 호출 실패")
+        )
+        with patch("src.interfaces.dependencies.prewalk_orchestrator", mock_orchestrator):
+            response = client.post(
+                "/api/prewalk/intent",
+                json={"thread_id": "thread-abc-123", "user_prompt": "산책 추천해줘"},
+            )
+        assert response.status_code == 500
 
 
 # ── GET /api/map/facilities ──────────────────────────────────────────────────


### PR DESCRIPTION
## ☝️Issue Number
- resolve #226 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 챗봇 플로우 전 레이어(Router → Service → Node)에 예외처리 및 로깅을 추가했습니다.

**Router**
- /init, /intent 양쪽에 `except Exception` 추가 → 미처리 예외는 HTTP 500 반환

**Service (PrewalkOrchestrator)**
- 날씨·카카오 API 실패: graceful fallback (기본 인사 메시지 / 좌표만으로 Location 구성)
- DB(UserRepository, ChatSessionRepository), graph.ainvoke() 실패: INTERNAL_ERROR 반환
- ChatStateRepository 저장 실패: 로그만 기록 후 정상 응답 유지

**Node**
- WeatherChecker: 날씨 API, 대기질 API, LLM 각각 개별 try/except
- Extractor: LLM 호출 2곳 try/except → 실패 시 state 그대로 반환
- Interviewer: LLM 호출 4곳 try/except → 실패 시 fallback 안내 메시지

**Schema**
- ChatStatus에 INTERNAL_ERROR 추가
- ChatRequest.user_prompt 공백 입력 시 422 validator 추가 (TC-CHAT-007)

**테스트**
- 기존 prewalk 테스트 코드 오류 수정 (State 필드, mock 패치 경로)
- TC-PREWALK 누락 케이스 4개 추가 (500, 422 공백, session_not_found, 500 intent)

**수정 파일**
- `src/interfaces/schema/prewalk_schema.py`
- `src/interfaces/api/prewalk_router.py`
- `src/service/chat/prewalk_service.py`
- `src/agent/nodes/weather_checker.py`
- `src/agent/nodes/extractor.py`
- `src/agent/nodes/interviewer.py`
- `tests/integration/test_api.py`
