### PR TITLE
[Fix] 챗봇 경로 생성 전 확인 단계 추가

### DIFF
--- a/src/agent/nodes/extractor.py
+++ b/src/agent/nodes/extractor.py
@@ -45,7 +45,7 @@ class Extractor(GPTClient):
         if not res or not res.tool_calls:
             logger.warning("LLM이 산책 모드를 결정하지 못했습니다.")
             return state
-        
+
         tool_call = res.tool_calls[0]
         tool_name = tool_call["name"]  # LLM이 결정한 산책 모드
 
@@ -53,11 +53,27 @@ class Extractor(GPTClient):
         if tool_name not in self.mode_tool.tool_map:
             logger.warning(f"LLM이 정의되지 않은 산책 모드를 사용합니다: {tool_name}")
             return state
-        
+
         # LLM이 추출한 산책 모드 외 정보
         args = tool_call["args"]
 
-        # 예외3. 출발지가 없는 경우
+        # 예외3. origin과 destination이 동일한 장소명인데 명시적 출발지 표현이 없는 경우
+        # (e.g., "용산역으로 가는 길 알려줘" → origin을 null로 보정해 현재 위치로 대체)
+        _EXPLICIT_ORIGIN_MARKERS = ("에서", "부터", "출발", "시작")
+        origin_arg = args.get("origin")
+        dest_arg   = args.get("destination")
+        if origin_arg and dest_arg:
+            origin_name = origin_arg.get("place_name") if isinstance(origin_arg, dict) else None
+            dest_name   = dest_arg.get("place_name")   if isinstance(dest_arg,   dict) else None
+            if origin_name and dest_name and origin_name == dest_name:
+                if not any(m in state.user_prompt for m in _EXPLICIT_ORIGIN_MARKERS):
+                    args["origin"] = None
+                    logger.warning(
+                        f"origin과 destination이 동일한 장소명({origin_name})이며 "
+                        f"명시적 출발지 표현이 없어 origin을 null로 보정합니다."
+                    )
+
+        # 예외4. 출발지가 없는 경우
         if args.get("origin") is None:
             args["origin"] = state.current_location.model_dump()
             logger.warning(f"출발지가 정해지지 않아, 현 위치를 출발지로 설정합니다: {args['origin']}")

--- a/src/agent/nodes/interviewer.py
+++ b/src/agent/nodes/interviewer.py
@@ -16,6 +16,8 @@ from src.schema.prewalk_schema import (
     OnewayShortestPreference,
 )
 
+_FALLBACK_RESPONSE = "죄송해요, 일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요."
+
 logger = logging.getLogger(__name__)
 
 class Interviewer(GPTClient):
@@ -28,8 +30,8 @@ class Interviewer(GPTClient):
 
     async def run(self, state: State) -> State:
         """
-        정보가 부족하다면 -> 질문을 던지고
-        정보가 충분하면   -> 경로 생성 시작을 알리는 메시지를 제공합니다.
+        정보가 부족하다면 → 질문을 던지고
+        정보가 충분하면   → 확인 메시지를 생성한다(경로는 사용자 확인 후 실행).
         """
         is_complete  = self._is_complete(state.user_context)
         missing_info = self._get_missing_info(state.user_context)
@@ -44,91 +46,78 @@ class Interviewer(GPTClient):
             "user_input":       state.user_prompt,
         }
 
-        _FALLBACK_RESPONSE = "죄송해요, 일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요."
-
-        # 정보가 충분하다면 -> 경로 생성 시작을 알리는 메시지 제공
+        # 정보가 충분하면 → 사용자 확인 질문 생성 (경로 실행은 확인 후)
         if is_complete:
+            state.awaiting_confirmation = True
+            state.is_complete           = False
+            state.response              = self._build_confirmation_message(state)
+            logger.info(f"확인 대기 상태로 전환합니다: {state.response}")
+            return state
+
+        # 정보가 부족하면 → interview.yaml 호출
+        try:
+            raw_response = await super().get_response(
+                prompt_name="interview",
+                input_variables=input_variables,
+                llm=self.model,
+            )
+        except Exception:
+            logger.exception("interviewer_interview_llm_error")
+            state.response = _FALLBACK_RESPONSE
+            return state
+        logger.info("interview.yaml이 호출되었습니다.")
+
+        candidates = await self._execute_tool_calls(
+            raw_response.tool_calls if raw_response.tool_calls else [],
+            state,
+        )
+
+        if candidates:
+            if "origin_candidate" in candidates:
+                state.origin_candidate = candidates["origin_candidate"]
+                if state.user_context and candidates["origin_candidate"]:
+                    state.user_context.origin = candidates["origin_candidate"][0]
+                    logger.info(f"origin_candidate: {candidates['origin_candidate']}")
+                    logger.info(f"origin: {state.user_context.origin}")
+
+            if "destination_candidate" in candidates:
+                state.destination_candidate = candidates["destination_candidate"]
+                if state.user_context and hasattr(state.user_context, "destination") and candidates["destination_candidate"]:
+                    state.user_context.destination = candidates["destination_candidate"][0]
+                    logger.info(f"destination_candidate: {candidates['destination_candidate']}")
+                    logger.info(f"destination: {state.user_context.destination}")
+
+            is_complete = self._is_complete(state.user_context)
+            logger.info(f"is_complete을 재확인합니다: is_complete = {is_complete}")
+
+            # 장소 검색 후 정보가 충분해진 경우 → 확인 질문
+            if is_complete:
+                state.awaiting_confirmation = True
+                state.is_complete           = False
+                state.response              = self._build_confirmation_message(state)
+                logger.info(f"확인 대기 상태로 전환합니다: {state.response}")
+                return state
+
             try:
                 response = await super().get_response(
-                    prompt_name     = "complete",
-                    input_variables = input_variables,
-                    parser          = self.str_parser,
+                    prompt_name="location_formatter",
+                    input_variables={
+                        "tool_calls":       self.prompt_utils.format_for_prompt(candidates),
+                        "user_input":       state.user_prompt,
+                        "current_location": self.prompt_utils.format_for_prompt(state.current_location),
+                    },
+                    parser=self.str_parser,
                 )
             except Exception:
-                logger.exception("interviewer_complete_llm_error")
+                logger.exception("interviewer_location_formatter_llm_error")
                 response = _FALLBACK_RESPONSE
-            logger.info("complete.yaml이 호출되었습니다.")
-        # 정보가 부족하다면 -> 질문
+            logger.info("location_formatter.yaml이 호출되었습니다.")
         else:
-            try:
-                raw_response = await super().get_response(
-                    prompt_name="interview",
-                    input_variables=input_variables,
-                    llm=self.model,
-                )
-            except Exception:
-                logger.exception("interviewer_interview_llm_error")
-                state.response = _FALLBACK_RESPONSE
-                return state
-            logger.info("interview.yaml이 호출되었습니다.")
+            response = raw_response.content
 
-            candidates = await self._execute_tool_calls(
-                raw_response.tool_calls if raw_response.tool_calls else [],
-                state,
-            )
-
-            if candidates:
-                if "origin_candidate" in candidates:
-                    state.origin_candidate = candidates["origin_candidate"]
-                    if state.user_context and candidates["origin_candidate"]:
-                        state.user_context.origin = candidates["origin_candidate"][0]
-                        logger.info(f"origin_candidate: {candidates['origin_candidate']}")
-                        logger.info(f"origin: {state.user_context.origin}")
-
-                if "destination_candidate" in candidates:
-                    state.destination_candidate = candidates["destination_candidate"]
-                    if state.user_context and hasattr(state.user_context, "destination") and candidates["destination_candidate"]:
-                        state.user_context.destination = candidates["destination_candidate"][0]
-                        logger.info(f"destination_candidate: {candidates['destination_candidate']}")
-                        logger.info(f"destination: {state.user_context.destination}")
-
-                is_complete = self._is_complete(state.user_context)
-                logger.info(f"is_complete을 재확인합니다: is_complete = {is_complete}")
-
-                if is_complete:
-                    input_variables["current_context"] = self.prompt_utils.format_for_prompt(state.user_context)
-                    try:
-                        response = await super().get_response(
-                            prompt_name="complete",
-                            input_variables=input_variables,
-                            parser=self.str_parser,
-                        )
-                    except Exception:
-                        logger.exception("interviewer_complete_llm_error")
-                        response = _FALLBACK_RESPONSE
-                    logger.info("complete.yaml이 호출되었습니다.")
-                else:
-                    try:
-                        response = await super().get_response(
-                            prompt_name="location_formatter",
-                            input_variables={
-                                "tool_calls":       self.prompt_utils.format_for_prompt(candidates),
-                                "user_input":       state.user_prompt,
-                                "current_location": self.prompt_utils.format_for_prompt(state.current_location),
-                            },
-                            parser=self.str_parser,
-                        )
-                    except Exception:
-                        logger.exception("interviewer_location_formatter_llm_error")
-                        response = _FALLBACK_RESPONSE
-                    logger.info("location_formatter.yaml이 호출되었습니다.")
-            else:
-                response = raw_response.content
-
-
-        state.is_complete = is_complete
+        state.is_complete = False
         state.response    = response
-        
+
         logger.info(f"response: {state.response}")
         logger.info(f"user_context: {state.user_context.model_dump_json() if state.user_context else None}")
 
@@ -175,6 +164,41 @@ class Interviewer(GPTClient):
 
         return ", ".join(missing) if missing else ""
 
+    def _is_same_location(self, a: Optional[Location], b: Optional[Location]) -> bool:
+        """두 Location이 같은 지점인지 좌표 기준으로 비교합니다."""
+        if a is None or b is None:
+            return False
+        if (a.lat is not None and b.lat is not None
+                and a.lon is not None and b.lon is not None):
+            return abs(a.lat - b.lat) < 1e-6 and abs(a.lon - b.lon) < 1e-6
+        return False
+
+    def _build_confirmation_message(self, state: State) -> str:
+        """경로 실행 전 사용자에게 보낼 확인 질문을 생성합니다."""
+        ctx     = state.user_context
+        current = state.current_location
+
+        if isinstance(ctx, (OnewayShortestPreference, OnewayPreference)):
+            origin    = ctx.origin
+            dest      = ctx.destination
+            dest_name = dest.place_name if dest and dest.place_name else "목적지"
+
+            if self._is_same_location(origin, current):
+                return f"현재 위치부터 {dest_name}까지가 맞나요?"
+            origin_name = origin.place_name if origin and origin.place_name else "현재 위치"
+            return f"{origin_name}부터 {dest_name}까지가 맞나요?"
+
+        if isinstance(ctx, CircularPreference):
+            origin    = ctx.origin
+            target_km = ctx.target_km or 3.0
+            km_str    = str(int(target_km)) if target_km == int(target_km) else str(target_km)
+
+            if self._is_same_location(origin, current):
+                return f"현재 위치에서 출발하는 {km_str}km 순환 산책이 맞나요?"
+            origin_name = origin.place_name if origin and origin.place_name else "현재 위치"
+            return f"{origin_name}에서 출발하는 {km_str}km 순환 산책이 맞나요?"
+
+        return "이 경로로 진행할까요?"
 
     async def _execute_tool_calls(self, tool_calls: list, state: State) -> dict:
         candidates = {}

--- a/src/route_engine/engines/path_utils.py
+++ b/src/route_engine/engines/path_utils.py
@@ -4,7 +4,7 @@ import random
 import networkx as nx
 
 _R1_M: float = 30.0   # ROUT-NODE 1차 탐색 반경 (m)
-_R2_M: float = 100.0  # ROUT-NODE 2차 탐색 반경 (m)
+_R2_M: float = 300.0  # ROUT-NODE 2차 탐색 반경 (m)
 
 
 class PathUtils:

--- a/src/schema/prewalk_schema.py
+++ b/src/schema/prewalk_schema.py
@@ -68,6 +68,7 @@ class State(BaseModel):
     weather_data: Optional[EnvironmentInfo] = None
     route_result: Optional[WalkRouteResponse] = None
     is_complete: bool = False
+    awaiting_confirmation: bool = False
     user_prompt: str  = ""
     response:    str  = ""
     themes: List[str] = []

--- a/src/service/chat/prewalk_service.py
+++ b/src/service/chat/prewalk_service.py
@@ -20,6 +20,15 @@ from src.service.user.auth_service import AuthService
 logger = logging.getLogger(__name__)
 
 
+_NEGATIVE_WORDS = frozenset([
+    "아니", "아니요", "아냐", "틀려", "다시", "잠깐", "수정", "변경", "바꿔", "말고", "no", "nope",
+])
+_POSITIVE_WORDS = frozenset([
+    "응", "네", "맞아", "맞아요", "맞습니다", "좋아", "좋아요", "그래", "그래요",
+    "진행", "진행해", "경로 만들어", "예", "ok", "okay", "yes", "ㅇ", "ㅇㅇ", "넹", "넵",
+])
+
+
 class PrewalkOrchestrator:
     def __init__(
         self,
@@ -33,7 +42,20 @@ class PrewalkOrchestrator:
         self.weather_checker = weather_checker
         self.kakao_client    = kakao_client
         self.auth_service    = auth_service
+        self.route_executor  = route_executor
         self.graph           = self._build_graph(extractor, interviewer, route_executor)
+
+    @staticmethod
+    def _is_positive_response(text: str) -> bool:
+        """사용자 입력이 긍정 응답인지 판단합니다. 부정 표현이 있으면 무조건 False."""
+        t = text.strip().lower()
+        for w in _NEGATIVE_WORDS:
+            if w in t:
+                return False
+        for w in _POSITIVE_WORDS:
+            if w in t:
+                return True
+        return False
 
     def _build_graph(self, extractor, interviewer, route_executor):
         """
@@ -145,17 +167,40 @@ class PrewalkOrchestrator:
         if state.user_id != user.id:
             return ChatResponse(status=ChatStatus.UNACCESSIBLE, thread_id=None, state=None)
 
-        # 최근 프롬프트로 업데이트
-        state.user_prompt  = user_prompt
         state.access_token = access_token
 
-        # state 업데이트
-        try:
-            result      = await self.graph.ainvoke(state)
-            final_state = State.model_validate(result)
-        except Exception:
-            logger.exception("prewalk_intent_graph_error | thread_id=%s", thread_id)
-            return ChatResponse(status=ChatStatus.INTERNAL_ERROR, thread_id=None, state=None)
+        # awaiting_confirmation=True: 사용자 확인 응답 처리
+        if state.awaiting_confirmation:
+            state.user_prompt = user_prompt
+            if self._is_positive_response(user_prompt):
+                # 긍정 → route_executor 직접 실행 (LangGraph 우회)
+                state.awaiting_confirmation = False
+                state.is_complete           = True
+                state.response              = "경로를 생성하고 있어요. 잠시만 기다려주세요 🗺️"
+                try:
+                    final_state = await self.route_executor.run(state)
+                except Exception:
+                    logger.exception("prewalk_intent_route_executor_error | thread_id=%s", thread_id)
+                    return ChatResponse(status=ChatStatus.INTERNAL_ERROR, thread_id=None, state=None)
+            else:
+                # 부정/수정 → 확인 대기 해제 후, 무엇을 바꿀지 되묻고 멈춤
+                # (LangGraph 재실행 X: "아니"만으로는 새 정보가 없어 같은 확인 질문이 반복되기 때문)
+                # user_context는 유지 → 다음 턴에서 "3km로 바꿔줘"처럼 일부만 수정 가능
+                state.awaiting_confirmation = False
+                state.is_complete           = False
+                state.route_result          = None
+                state.response = "알겠어요. 어떤 부분을 바꿀까요? 출발지, 목적지, 거리 중 원하는 내용을 다시 알려주세요."
+                final_state = state
+
+        else:
+            # 일반 흐름 → LangGraph 실행
+            state.user_prompt = user_prompt
+            try:
+                result      = await self.graph.ainvoke(state)
+                final_state = State.model_validate(result)
+            except Exception:
+                logger.exception("prewalk_intent_graph_error | thread_id=%s", thread_id)
+                return ChatResponse(status=ChatStatus.INTERNAL_ERROR, thread_id=None, state=None)
 
         try:
             await ChatStateRepository.save_state(thread_id, final_state)


### PR DESCRIPTION
## ☝️Issue Number
- resolve #228 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 출발지/목적지가 모두 채워져도 즉시 경로 생성하지 않고 확인 메시지를 반환하도록 수정
- 사용자가 긍정 응답을 보낸 경우에만 route_executor를 실행하도록 변경
- 목적지만 입력한 경우 출발지를 현재 위치로 보정하도록 처리
- nearest node 2차 탐색 반경을 100m에서 300m로 확장
- 
!image.png

오타는 허용안됨

응 이라고하면 

!image.png

##다음작업

'아니' 라고할 경우,  현재 순환으로 고정되어 아니라고 한 경우 재차 질문하는 부분 
승리님 작업으로 멈춤 