### PR TITLE
Fix: 챗봇 경로 전환 시 이전 경로 지도 잔류 버그 수정

### DIFF
--- a/frontend/streamlit_prototype/components/panel/chat_panel.py
+++ b/frontend/streamlit_prototype/components/panel/chat_panel.py
@@ -102,9 +102,7 @@ class ChatPanel:
         st.session_state.messages.append({"role": "assistant", "content": answer})
         st.session_state.state = state
 
-        route_result = state.get("route_result")
-        if route_result:
-            st.session_state.route_result = route_result
+        st.session_state.route_result = state.get("route_result")
 
     def _render_route_map(self, route_result: dict) -> None:
         """

--- a/src/service/chat/prewalk_service.py
+++ b/src/service/chat/prewalk_service.py
@@ -195,6 +195,7 @@ class PrewalkOrchestrator:
         else:
             # 일반 흐름 → LangGraph 실행
             state.user_prompt = user_prompt
+            state.route_result = None
             try:
                 result      = await self.graph.ainvoke(state)
                 final_state = State.model_validate(result)


### PR DESCRIPTION
## ☝️Issue Number
- resolve #232 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 챗봇 모드 전환(순환 ↔ 편도) 시 이전 경로 지도가 잔류하는 버그 수정
- 백엔드: 새 대화 턴 시작 시 state.route_result를 None으로 초기화하여 API 응답에 이전 경로가 포함되지 않도록 처리
- 프론트엔드: API 응답의 route_result를 항상 session_state에 반영하도록 변경
  (기존에는 None일 경우 갱신 생략 → 이전 경로 잔류)

## 수정된 파일
- src/service/chat/prewalk_service.py — LangGraph 실행 전 state.route_result = None 추가
- frontend/streamlit_prototype/components/panel/chat_panel.py — if route_result: 조건 제거, 항상 st.session_state.route_result 갱신
