### PR TITLE
feat: 카카오 RN 앱 로그인 플로우 분리 및 응답 토큰 body 추가

### DIFF
--- a/src/interfaces/api/login_router.py
+++ b/src/interfaces/api/login_router.py
@@ -1,6 +1,6 @@
-from fastapi import APIRouter, Depends, Query, Request, Response
+from fastapi import APIRouter, Body, Depends, Query, Request, Response
 from src.service.user.login_service import KakaoLoginService
-from src.interfaces.schema.login_schema import LoginUrlResponse, LoginResponse
+from src.interfaces.schema.login_schema import LoginUrlResponse, LoginResponse, MobileLoginRequest
 from src.interfaces.schema.auth_schema import AuthResponse, Status
 from src.interfaces.dependencies import get_kakao_login_service
 
@@ -22,17 +22,17 @@ def get_kakao_login_url(
 @router.get("/kakao/callback", response_model=LoginResponse)
 async def kakao_callback(
     response: Response,
-    code: str = Query(...),
+    code: str = Query(..., description="카카오 OAuth 인가 코드"),
     service: KakaoLoginService = Depends(get_kakao_login_service)
 ):
     """
-    카카오 인가 코드로 로그인을 처리하고 access/refresh 토큰을 쿠키에 저장합니다.
+    카카오 인가 코드로 로그인을 처리합니다 (웹/Streamlit OAuth 리다이렉트 흐름).
     """
-    access_token, refresh_token, nickname = await service.login(code)
+    jwt_access_token, refresh_token, nickname = await service.login(code)
 
     response.set_cookie(
         key="access_token",
-        value=access_token,
+        value=jwt_access_token,
         httponly=True,
         secure=False,  # 배포 시에는 True로 설정하여 HTTPS 환경에서만 전송되도록 수정
         samesite="lax",
@@ -47,7 +47,19 @@ async def kakao_callback(
         samesite="lax",
         max_age=14 * 24 * 60 * 60
     )
-    return LoginResponse(status=Status.SUCCESS, token_type="Bearer", nickname=nickname, access_token=access_token, refresh_token=refresh_token)
+    return LoginResponse(status=Status.SUCCESS, token_type="Bearer", nickname=nickname, access_token=jwt_access_token, refresh_token=refresh_token)
+
+@router.post("/kakao/mobile-login", response_model=LoginResponse)
+async def kakao_mobile_login(
+    body: MobileLoginRequest,
+    service: KakaoLoginService = Depends(get_kakao_login_service)
+):
+    """
+    카카오 액세스 토큰으로 로그인합니다 (RN 앱 전용).
+    @react-native-seoul/kakao-login SDK가 발급한 액세스 토큰을 body로 받습니다.
+    """
+    jwt_access_token, refresh_token, nickname = await service.login_with_access_token(body.access_token)
+    return LoginResponse(status=Status.SUCCESS, token_type="Bearer", nickname=nickname, access_token=jwt_access_token, refresh_token=refresh_token)
 
 @router.post("/kakao/logout", response_model=AuthResponse)
 async def kakao_logout(

--- a/src/interfaces/schema/login_schema.py
+++ b/src/interfaces/schema/login_schema.py
@@ -9,3 +9,6 @@ class LoginResponse(UserResponse):
     token_type: str = "Bearer"
     access_token: str
     refresh_token: str
+
+class MobileLoginRequest(BaseModel):
+    access_token: str

--- a/src/service/user/login_service.py
+++ b/src/service/user/login_service.py
@@ -93,7 +93,7 @@ class KakaoLoginService:
         
     async def login(self, code: str):
         """
-        로그인을 진행합니다.
+        인가 코드로 로그인합니다 (웹/Streamlit OAuth 리다이렉트 흐름).
         """
         kakao_access_token = await self.get_access_token(code)
         provider_id, nickname = await self.get_user_info(kakao_access_token)
@@ -103,6 +103,20 @@ class KakaoLoginService:
 
         user = await self.user_service.save(Provider.KAKAO, provider_id, jwt_refresh_token, nickname)
         
+        return jwt_access_token, jwt_refresh_token, nickname
+
+    async def login_with_access_token(self, kakao_access_token: str):
+        """
+        카카오 액세스 토큰으로 로그인합니다 (RN 앱 흐름).
+        @react-native-seoul/kakao-login SDK가 토큰을 직접 발급하므로 인가 코드 교환 단계를 건너뜁니다.
+        """
+        provider_id, nickname = await self.get_user_info(kakao_access_token)
+
+        jwt_access_token = self.auth_service.get_access_token(Provider.KAKAO, provider_id)
+        jwt_refresh_token = self.auth_service.get_refresh_token(Provider.KAKAO, provider_id)
+
+        await self.user_service.save(Provider.KAKAO, provider_id, jwt_refresh_token, nickname)
+
         return jwt_access_token, jwt_refresh_token, nickname
 
 


### PR DESCRIPTION
## ☝️Issue Number
- resolve #276 #277 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
### 수정 파일

파일: src/interfaces/schema/login_schema.py
변경 유형: 수정
내용: LoginResponse에 access_token, refresh_token
  필드 추가 / MobileLoginRequest 스키마 신규 추가
────────────────────────────────────────
파일: src/interfaces/api/login_router.py
변경 유형: 수정
내용: kakao_callback을 code 파라미터로 원복 /
  POST /kakao/mobile-login 엔드포인트 신규 추가
────────────────────────────────────────
파일: src/service/user/login_service.py
변경 유형: 수정
내용: login_with_access_token() 메서드 신규 추가
  / login() docstring 정비

### 구현 기능

1. 로그인 응답 body에 토큰 포함
  - LoginResponse 스키마에 access_token, refresh_token 필드를 추가해, 쿠키를 쓰지 않는 클라이언트(RN 앱)도 JSON body로 JWT 토큰을 수신할 수 있게 함.
2. POST /api/login/kakao/mobile-login (RN 앱 전용)
  - Request body: { "access_token": "<카카오_액세스_토큰>" }
  - RN SDK가 직접 발급한 카카오 액세스 토큰을 받아 get_user_info() → 회원 저장 → JWT 발급 순서로 처리. 인가 코드 교환(get_access_token()) 단계 없음.
  - 쿠키를 심지 않고 body로만 JWT를 반환 (RN 앱은 쿠키 대신 앱 스토리지에 직접 저장).
3. GET /api/login/kakao/callback 웹 흐름 보호
  - 파라미터를 code로 유지해 Streamlit 클라이언트의 OAuth 리다이렉트 흐름이 그대로 동작하도록 보장.
