### PR TITLE
[TEST/#284] 순환 길찾기 알고리즘 벤치마크 하네스 연결

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -38,11 +38,15 @@ import multiprocessing
 import queue
 import time
 
+import networkx as nx
 import pandas as pd
 
-from benchmarks.config import BENCH_DIR
+from benchmarks.config import BENCH_DIR, ROUTE_EDGES_PARQUET, ROUTE_NODES_PARQUET
+from benchmarks.solvers.alns_solver import AlnsSolver
 from benchmarks.solvers.base_solver import BasePathSolver
+from benchmarks.solvers.beam_solver import BeamSolver
 from benchmarks.solvers.dummy_solver import DummySolver
+from benchmarks.solvers.grasp_solver import GraspSolver
 
 logger = logging.getLogger(__name__)
 
@@ -58,9 +62,11 @@ DEFAULT_TIMEOUT_SEC = 30.0
 KILL_GRACE_SEC = 2.0  # terminate(SIGTERM) 후 kill(SIGKILL)로 넘어가기 전 대기 시간
 QUEUE_FLUSH_GRACE_SEC = 5.0  # 자식 프로세스 종료 후 큐에 결과가 도착할 때까지 대기 시간
 
-# 벤치마크 대상 알고리즘 등록 지점. 실제 알고리즘 연결 시 여기에 항목만 추가하면 된다.
-# 예: "rcsp": RcspSolver()
+# 벤치마크 대상 알고리즘 등록 지점.
 SOLVER_REGISTRY: dict[str, BasePathSolver] = {
+    "grasp": GraspSolver(),
+    "beam": BeamSolver(),
+    "alns": AlnsSolver(),
     "dummy-a": DummySolver(name="DummySolver-A", fake_delay_sec=0.05),
     "dummy-b": DummySolver(name="DummySolver-B", fake_delay_sec=0.1),
 }
@@ -334,7 +340,58 @@ def parse_args(argv=None) -> argparse.Namespace:
         default=DEFAULT_TIMEOUT_SEC,
         help=f"solver별 제한시간(초). 초과 시 해당 solver만 실패 처리 (기본값: {DEFAULT_TIMEOUT_SEC})",
     )
+    parser.add_argument(
+        "--target-km",
+        type=float,
+        default=3.0,
+        help="순환 경로 목표 거리(km) (기본값: 3.0)",
+    )
+    parser.add_argument(
+        "--time-budget",
+        type=float,
+        default=None,
+        help="사용자 체감 허용시간(초). 지정 시 within_time_budget 컬럼이 채워짐",
+    )
+    parser.add_argument(
+        "--start-node",
+        type=int,
+        default=None,
+        help="시작 노드 ID. 미지정 시 그래프에서 자동 선택",
+    )
     return parser.parse_args(argv)
+
+
+def _load_default_graph() -> nx.Graph | None:
+    """benchmarks/fixtures의 실제 서울 도보 그래프를 로드한다.
+
+    fixture가 아직 빌드되지 않았으면(benchmarks/build_fixtures.py 미실행) None을 반환해
+    dummy 알고리즘만으로도 하네스를 계속 사용할 수 있게 한다.
+    """
+    if not ROUTE_NODES_PARQUET.exists() or not ROUTE_EDGES_PARQUET.exists():
+        logger.warning(
+            "그래프 fixture(%s, %s)가 없습니다. 'python -m benchmarks.build_fixtures'로 먼저 생성하세요. "
+            "그래프 없이 진행합니다(dummy 알고리즘만 유효).",
+            ROUTE_NODES_PARQUET, ROUTE_EDGES_PARQUET,
+        )
+        return None
+
+    nodes_df = pd.read_parquet(ROUTE_NODES_PARQUET)
+    edges_df = pd.read_parquet(ROUTE_EDGES_PARQUET)
+
+    graph = nx.Graph()
+    for row in nodes_df.itertuples():
+        graph.add_node(row.node_id, lat=row.lat, lon=row.lon)
+    for row in edges_df.itertuples():
+        graph.add_edge(
+            row.u, row.v,
+            length=row.length,
+            safety_score=getattr(row, "safety_score", 0.5) or 0.5,
+            nature_score=getattr(row, "nature_score", 0.5) or 0.5,
+            landmark_score=getattr(row, "landmark_score", 0.0) or 0.0,
+            child_score=getattr(row, "child_score", 0.0) or 0.0,
+            slope_score=0.5,
+        )
+    return graph
 
 
 def main():
@@ -346,10 +403,20 @@ def main():
             print(f"  - {key}")
         return
 
-    # ── 인터페이스 검증용 예시 입력 (실제 알고리즘 연결 전 더미 데이터) ──
-    graph = None
-    start_node, target_node = "A", "B"
-    params = {}
+    graph = _load_default_graph()
+
+    if args.start_node is not None:
+        start_node = args.start_node
+    elif graph is not None:
+        largest_cc = max(nx.connected_components(graph), key=len)
+        start_node = sorted(largest_cc)[0]
+    else:
+        start_node = "A"  # dummy 알고리즘용 폴백
+
+    target_node = start_node  # 순환 경로는 출발지로 복귀하므로 start와 동일
+    params = {"target_km": args.target_km}
+    if args.time_budget is not None:
+        params["time_budget_sec"] = args.time_budget
 
     solvers = resolve_solvers(args.algo)
 

--- a/benchmarks/solvers/_circular_engine_common.py
+++ b/benchmarks/solvers/_circular_engine_common.py
@@ -1,0 +1,39 @@
+"""
+benchmarks/solvers/_circular_engine_common.py
+
+circular_grasp / circular_beam / circular_alns 세 엔진 모두 동일한 구조를 가진다:
+  1) calculate_custom_score(G, ...)로 edge별 가중치 점수 부여
+  2) find_path(start_node, target_km)로 노드ID 경로 생성
+  3) prune_dead_ends(nodes)로 왕복 잔가지 제거
+
+engine.run()은 이 결과를 좌표(lat/lon) 리스트로 변환해서 반환하지만, 벤치마크 하네스는
+graph edge 'length'를 직접 합산해 거리/루프폐합/잔가시/왕복겹침을 독립적으로 검증하므로
+노드ID 경로가 필요하다. 그래서 run()을 그대로 쓰지 않고, run()과 동일한 순서를 재현해
+좌표 변환 이전 단계의 결과를 얻는다 (엔진 알고리즘 자체는 건드리지 않음).
+"""
+
+from src.route_engine.scoring.scoring_engine import calculate_custom_score
+
+
+def run_circular_engine(engine, start_node: int, target_km: float) -> tuple[list, float]:
+    """CircularXxxEngine 인스턴스에서 노드ID 경로와 누적 custom_score(cost)를 얻는다.
+
+    경로 생성에 실패하면(빈 경로/시작 노드만 반환/잔가지 제거 후 경로 소실) ValueError를
+    던진다 — 벤치마크 하네스가 이를 status="failed" 행으로 안전하게 처리한다.
+    """
+    calculate_custom_score(engine.G, {
+        "mode": engine.scoring_mode,
+        "weights": engine.weights,
+        "blocked_tags": engine.blocked_tags,
+    })
+
+    nodes = engine.find_path(start_node, target_km)
+    if not nodes or len(nodes) < 2:
+        raise ValueError("경로 생성 실패: 유효한 순환 경로를 찾지 못했습니다 (NO_PATH)")
+
+    pruned = engine.utils.prune_dead_ends(nodes)
+    if len(pruned) < 2:
+        raise ValueError("경로 생성 실패: 잔가지 제거 후 남은 경로가 없습니다")
+
+    _, cost = engine.utils.metrics(pruned)
+    return pruned, cost

--- a/benchmarks/solvers/alns_solver.py
+++ b/benchmarks/solvers/alns_solver.py
@@ -1,0 +1,34 @@
+"""
+benchmarks/solvers/alns_solver.py
+
+src/route_engine/engines/circular_alns.py (ALNS)를 BasePathSolver 규격으로 감싸는 어댑터.
+"""
+
+from benchmarks.solvers._circular_engine_common import run_circular_engine
+from benchmarks.solvers.base_solver import BasePathSolver
+from src.route_engine.engines.circular_alns import CircularAlnsEngine
+from src.schema.route_schema import CircularRouteInput
+
+_DEFAULT_TARGET_KM = 3.0
+_DEFAULT_SEED = 42
+
+
+class AlnsSolver(BasePathSolver):
+    def __init__(self, name: str = "ALNS", seed: int = _DEFAULT_SEED):
+        super().__init__(name)
+        self.seed = seed
+
+    def solve(self, graph, start_node, target_node, params: dict) -> dict:
+        target_km = params.get("target_km") or _DEFAULT_TARGET_KM
+        inp = CircularRouteInput(start_lat=0.0, start_lon=0.0, target_km=target_km)
+
+        engine = CircularAlnsEngine(
+            inp=inp,
+            G=graph,
+            custom_weights=params.get("custom_weights"),
+            profile=params.get("profile"),
+            seed=self.seed,
+        )
+        path, cost = run_circular_engine(engine, start_node, target_km)
+
+        return {"paths": [path], "cost": cost, "overlap_ratio": 0.0}

--- a/benchmarks/solvers/beam_solver.py
+++ b/benchmarks/solvers/beam_solver.py
@@ -1,0 +1,32 @@
+"""
+benchmarks/solvers/beam_solver.py
+
+src/route_engine/engines/circular_beam.py (Beam Search)를 BasePathSolver 규격으로
+감싸는 어댑터.
+"""
+
+from benchmarks.solvers._circular_engine_common import run_circular_engine
+from benchmarks.solvers.base_solver import BasePathSolver
+from src.route_engine.engines.circular_beam import CircularBeamEngine
+from src.schema.route_schema import CircularRouteInput
+
+_DEFAULT_TARGET_KM = 3.0
+
+
+class BeamSolver(BasePathSolver):
+    def __init__(self, name: str = "Beam"):
+        super().__init__(name)
+
+    def solve(self, graph, start_node, target_node, params: dict) -> dict:
+        target_km = params.get("target_km") or _DEFAULT_TARGET_KM
+        inp = CircularRouteInput(start_lat=0.0, start_lon=0.0, target_km=target_km)
+
+        engine = CircularBeamEngine(
+            inp=inp,
+            G=graph,
+            custom_weights=params.get("custom_weights"),
+            profile=params.get("profile"),
+        )
+        path, cost = run_circular_engine(engine, start_node, target_km)
+
+        return {"paths": [path], "cost": cost, "overlap_ratio": 0.0}

--- a/benchmarks/solvers/grasp_solver.py
+++ b/benchmarks/solvers/grasp_solver.py
@@ -1,0 +1,35 @@
+"""
+benchmarks/solvers/grasp_solver.py
+
+src/route_engine/engines/circular_grasp.py (GRASP + VNS)를 BasePathSolver 규격으로
+감싸는 어댑터.
+"""
+
+from benchmarks.solvers._circular_engine_common import run_circular_engine
+from benchmarks.solvers.base_solver import BasePathSolver
+from src.route_engine.engines.circular_grasp import CircularGraspEngine
+from src.schema.route_schema import CircularRouteInput
+
+_DEFAULT_TARGET_KM = 3.0
+_DEFAULT_SEED = 42
+
+
+class GraspSolver(BasePathSolver):
+    def __init__(self, name: str = "GRASP+VNS", seed: int = _DEFAULT_SEED):
+        super().__init__(name)
+        self.seed = seed
+
+    def solve(self, graph, start_node, target_node, params: dict) -> dict:
+        target_km = params.get("target_km") or _DEFAULT_TARGET_KM
+        inp = CircularRouteInput(start_lat=0.0, start_lon=0.0, target_km=target_km)
+
+        engine = CircularGraspEngine(
+            inp=inp,
+            G=graph,
+            custom_weights=params.get("custom_weights"),
+            profile=params.get("profile"),
+            seed=self.seed,
+        )
+        path, cost = run_circular_engine(engine, start_node, target_km)
+
+        return {"paths": [path], "cost": cost, "overlap_ratio": 0.0}


### PR DESCRIPTION
## ☝️Issue Number
- resolve #284

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)

앞서 구축한 공통 테스트 환경(하네스, #282)에 실제 순환 길찾기 알고리즘 3종을 연결해서,
실제 알고리즘 간 성능/품질 비교가 가능하도록 했습니다.

- `GraspSolver` / `BeamSolver` / `AlnsSolver` — `src/route_engine/engines/circular_*.py`를
  `BasePathSolver` 규격으로 감싸는 어댑터. **기존 엔진 코드는 전혀 수정하지 않음**
- `benchmarks/solvers/_circular_engine_common.py` — 세 엔진이 공유하는 실행 순서(스코어링 →
  find_path → 잔가지 제거)를 재현하는 헬퍼. `engine.run()`은 결과를 좌표(lat/lon)로 변환해
  버리지만, 하네스는 노드ID 경로가 있어야 거리/루프폐합/잔가시/겹침을 독립 검증할 수 있어서
  좌표 변환 이전 단계까지만 재사용
- `benchmark.py`의 `SOLVER_REGISTRY`에 `"grasp"`, `"beam"`, `"alns"` 등록
- CLI가 실제 서울 도보 그래프 fixture를 자동 로딩하도록 개선, `--target-km` / `--time-budget`
  / `--start-node` 옵션 추가 (fixture 없으면 dummy 알고리즘만으로도 계속 동작)

## 🧪 검증 — 실제 서울 도보 그래프 (노드 160,328개 / 엣지 223,927개)

```
python -m benchmarks.benchmark --algo all --target-km 3.0 --time-budget 5.0
```

| algorithm | status | elapsed_sec | distance_deviation_km | is_closed_loop | spike_count | edge_overlap_ratio | within_time_budget |
|---|---|---|---|---|---|---|---|
| GRASP+VNS | ok | 1.17 | 0.036 | True | 0 | 0.000 | True |
| Beam | ok | 1.24 | 0.778 | True | 1 | 0.174 | True |
| ALNS | ok | 1.17 | 0.353 | True | 0 | 0.028 | True |

3개 알고리즘 실행 총 10.14초, 최대 메모리(RSS) 504MB, swap 0회, 타임아웃/크래시 없음.

**하네스가 실제로 알고리즘 품질 차이를 드러냄**: Beam이 목표거리 편차(0.78km)·잔가시(1개)·
왕복 구간 겹침(17.4%) 모두에서 가장 열등하게 나왔습니다. 애초에 이슈에서 지적됐던
"순환이 안 된다 / 잔가시가 있다 / 갈 때와 돌아올 때 같은 길을 공유한다" 문제를 정량적으로
잡아내는 지표들이 실제 알고리즘 실행에서 유의미한 차이를 보였습니다.

## 📦 완료 조건 (DoD)

- [x] `python -m benchmarks.benchmark --algo all` 실행 시 3개 알고리즘 전부 `status=ok`로 정상 동작
- [x] `distance_deviation_km` / `is_closed_loop` / `spike_count` / `edge_overlap_ratio` /
      `within_time_budget`이 실제 값으로 채워져 3개 알고리즘을 서로 비교 가능
- [x] 실제 서울 도보 네트워크 규모(노드 16만 개)에서도 하네스가 타임아웃/메모리 문제 없이 정상 동작


## 📁 변경 파일

```
benchmarks/
├── benchmark.py                        (수정)
└── solvers/
    ├── _circular_engine_common.py      (신규)
    ├── grasp_solver.py                 (신규)
    ├── beam_solver.py                  (신규)
    └── alns_solver.py                  (신규)
```
