### PR TITLE
[Feat] 경로 기록 즐겨찾기 필터 조회 API 추가

### DIFF
--- a/src/interfaces/api/user_router.py
+++ b/src/interfaces/api/user_router.py
@@ -5,6 +5,8 @@ src/interfaces/api/user_router.py
 현재 온보딩 설문 제출(POST /api/user/survey)을 제공합니다.
 """
 
+from typing import Optional
+
 from fastapi import APIRouter, Cookie, Depends, HTTPException
 import logging
 
@@ -62,11 +64,13 @@ def submit_survey(
 def get_route_histories(
     limit: int = 20,
     offset: int = 0,
+    is_favorite: Optional[bool] = None,
     access_token: str = Cookie(None),
     auth_service: AuthService = Depends(get_auth_service),
 ):
     """
     로그인한 사용자의 추천 경로 기록을 조회합니다.
+    is_favorite을 지정하면 즐겨찾기 여부로 필터링합니다(예: true → 즐겨찾기만).
     """
     try:
         status, provider, provider_id = auth_service.check_access_token(access_token)
@@ -80,7 +84,7 @@ def get_route_histories(
             raise HTTPException(status_code=404, detail="사용자를 찾을 수 없습니다.")
 
         histories = RouteHistoryRepository.find_by_user_id(
-            user.id, limit=limit, offset=offset
+            user.id, limit=limit, offset=offset, is_favorite=is_favorite
         )
         return RouteHistoryResponse(
             histories=[RouteHistoryItem.model_validate(h) for h in histories],

--- a/src/repository/user/route_history_repository.py
+++ b/src/repository/user/route_history_repository.py
@@ -35,12 +35,18 @@ class RouteHistoryRepository:
             return history
 
     @staticmethod
-    def find_by_user_id(user_id: int, limit: int = 20, offset: int = 0) -> list[RouteHistory]:
+    def find_by_user_id(
+        user_id: int,
+        limit: int = 20,
+        offset: int = 0,
+        is_favorite: Optional[bool] = None,
+    ) -> list[RouteHistory]:
         with get_postgresql_db() as db:
+            query = select(RouteHistory).where(RouteHistory.user_id == user_id)
+            if is_favorite is not None:
+                query = query.where(RouteHistory.is_favorite == is_favorite)
             query = (
-                select(RouteHistory)
-                .where(RouteHistory.user_id == user_id)
-                .order_by(RouteHistory.created_at.desc())
+                query.order_by(RouteHistory.created_at.desc())
                 .limit(limit)
                 .offset(offset)
             )


### PR DESCRIPTION
## 작업 내용
- GET /api/user/routes에 is_favorite 쿼리 파라미터 추가
- true로 주면 즐겨찾기한 경로만, 생략하면 기존처럼 전체 조회 (하위 호환 유지)

## 배경
- 프론트 기록 탭의 "즐겨찾기" 탭에서 즐겨찾기한 경로만 걸러서 보여주기 위해 필요
- 기존 find_by_user_id 호출부(스트림릿 프로토타입 등)는 파라미터 생략 시 그대로 동작

## 테스트
- 로컬에서 즐겨찾기 토글 후 is_favorite=true로 조회해 필터링 확인
