### PR TITLE
feat: 인증 확인 api를 쿠키에서 authorization 헤더 방식으로 전환

### DIFF
--- a/src/interfaces/api/auth_router.py
+++ b/src/interfaces/api/auth_router.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, Cookie, Response
+from fastapi import APIRouter, Depends, Response
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from src.interfaces.dependencies import get_auth_service
 from src.service.user.auth_service import AuthService
@@ -9,26 +10,30 @@ router = APIRouter(
     tags=["Auth"]
 )
 
+optional_bearer = HTTPBearer(auto_error=False)
+
 @router.get("/check/access_token", response_model=AuthResponse)
 def check_access_token(
-    access_token: str = Cookie(None),
+    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
     service: AuthService = Depends(get_auth_service)
 ):
     """
-    쿠키의 access_token 유효성을 검사합니다.
+    Authorization 헤더의 Bearer access_token 유효성을 검사합니다.
     """
+    access_token = credentials.credentials if credentials else None
     status, _, _ = service.check_access_token(access_token)
     return AuthResponse(status=status)
 
 @router.get("/check/refresh_token", response_model=AuthResponse)
 async def check_refresh_token(
     response: Response,
-    refresh_token: str = Cookie(None),
+    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
     service: AuthService = Depends(get_auth_service)
 ):
     """
-    refresh_token으로 access_token을 재발급하고 쿠키에 저장합니다.
+    Authorization 헤더의 Bearer refresh_token으로 access_token을 재발급하고 쿠키에 저장합니다.
     """
+    refresh_token = credentials.credentials if credentials else None
     status, access_token, _ = await service.check_refresh_token(refresh_token)
 
     # 재발급 성공 시에만 새 access_token을 쿠키에 저장합니다.
@@ -42,4 +47,5 @@ async def check_refresh_token(
             max_age=3600   # 1시간
         )
 
-    return AuthResponse(status=status)
+    # 쿠키를 사용할 수 없는 RN 앱을 위해 body에도 access_token을 포함합니다.
+    return AuthResponse(status=status, access_token=access_token if status == Status.SUCCESS else None)

--- a/src/interfaces/schema/auth_schema.py
+++ b/src/interfaces/schema/auth_schema.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Optional
 from pydantic import BaseModel
 
 class Status(str, Enum):
@@ -9,3 +10,4 @@ class Status(str, Enum):
 
 class AuthResponse(BaseModel):
     status: Status
+    access_token: Optional[str] = None


### PR DESCRIPTION
## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
### 1. src/interfaces/schema/auth_schema.py

- 변경 목적: AuthResponse에 access_token 필드 추가
- 이유: check_refresh_token API가 재발급된 access_token을 응답 body에도 실어 보낼 수 있도록 스키마를 확장.

---
### 2. src/interfaces/api/auth_router.py

- 변경 목적: 토큰 수신 방식을 Cookie → Authorization 헤더(HTTPBearer)로 전환

### (1) import 변경

**Before**
from fastapi import APIRouter, Depends, Cookie, Response

**After**
from fastapi import APIRouter, Depends, Response
from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials

- Cookie 제거
- HTTPBearer, HTTPAuthorizationCredentials 추가
---
### (2) optional_bearer 인스턴스 추가 (라우터 최상단)

optional_bearer = HTTPBearer(auto_error=False)

- auto_error=False: 헤더가 없어도 FastAPI가 직접 403을 반환하지 않고, None으로 넘겨 서비스 레이어에서 INVALID_TOKEN으로 처리하도록 함. 기존 Cookie(None) 동작과 동일한 흐름 유지.
---
### (3) check_access_token 파라미터 변경

**Before**
def check_access_token(
    access_token: str = Cookie(None),
    ...
):
    status, _, _ = service.check_access_token(access_token)

**After**
def check_access_token(
    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
    ...
):
    access_token = credentials.credentials if credentials else None
    status, _, _ = service.check_access_token(access_token)

- 쿠키 파라미터 → Depends(optional_bearer)로 교체
- credentials.credentials로 토큰 문자열 추출 (없으면 None)
- 서비스 호출부(service.check_access_token(access_token))는 그대로 유지
---
### (4) check_refresh_token 파라미터 변경

**Before**
async def check_refresh_token(
    response: Response,
    refresh_token: str = Cookie(None),
    ...
):
    status, access_token, _ = await service.check_refresh_token(refresh_token)

**After**
async def check_refresh_token(
    response: Response,
    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
    ...
):
    refresh_token = credentials.credentials if credentials else None
    status, access_token, _ = await service.check_refresh_token(refresh_token)

- 입력 방식만 헤더로 변경
- response.set_cookie(...) 쿠키 응답 로직은 그대로 유지 (웹 클라이언트 호환성 보존)
---
### (5) check_refresh_token 응답 변경

**Before**
return AuthResponse(status=status)

**After**
return AuthResponse(status=status, access_token=access_token if status == Status.SUCCESS else None)

- 재발급 성공 시 body에도 access_token을 포함하도록 변경 (쿠키 미지원 RN 앱 대응)

---
### 변경하지 않은 것

- service.check_access_token() / service.check_refresh_token() 호출 시그니처 — 그대로
- response.set_cookie() 로직 — 그대로
- kakao_callback, mobile-login 등 로그인(토큰 발급) API — 이번 변경 범위 밖
