### PR TITLE
[TEST] RCSP(oneway/circular) / Plateau method 벤치마크 solver 추가

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -47,6 +47,8 @@ from benchmarks.solvers.base_solver import BasePathSolver
 from benchmarks.solvers.beam_solver import BeamSolver
 from benchmarks.solvers.dummy_solver import DummySolver
 from benchmarks.solvers.grasp_solver import GraspSolver
+from benchmarks.solvers.plateau_solver import PlateauSolver
+from benchmarks.solvers.rcsp_solver import CircularRcspSolver, OnewayRcspSolver
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +69,9 @@ SOLVER_REGISTRY: dict[str, BasePathSolver] = {
     "grasp": GraspSolver(),
     "beam": BeamSolver(),
     "alns": AlnsSolver(),
+    "rcsp-circular": CircularRcspSolver(),
+    "rcsp-oneway": OnewayRcspSolver(),
+    "plateau": PlateauSolver(),
     "dummy-a": DummySolver(name="DummySolver-A", fake_delay_sec=0.05),
     "dummy-b": DummySolver(name="DummySolver-B", fake_delay_sec=0.1),
 }
@@ -358,6 +363,12 @@ def parse_args(argv=None) -> argparse.Namespace:
         default=None,
         help="시작 노드 ID. 미지정 시 그래프에서 자동 선택",
     )
+    parser.add_argument(
+        "--end-node",
+        type=int,
+        default=None,
+        help="도착 노드 ID. 미지정 시 start-node와 동일(순환 경로 기본값)",
+    )
     return parser.parse_args(argv)
 
 
@@ -413,7 +424,7 @@ def main():
     else:
         start_node = "A"  # dummy 알고리즘용 폴백
 
-    target_node = start_node  # 순환 경로는 출발지로 복귀하므로 start와 동일
+    target_node = args.end_node if args.end_node is not None else start_node  # 편도는 --end-node로 별도 지정
     params = {"target_km": args.target_km}
     if args.time_budget is not None:
         params["time_budget_sec"] = args.time_budget

--- a/benchmarks/solvers/_oneway_engine_common.py
+++ b/benchmarks/solvers/_oneway_engine_common.py
@@ -1,0 +1,69 @@
+"""
+benchmarks/solvers/_oneway_engine_common.py
+
+oneway_beam / oneway_grasp / oneway_alns / oneway_rcsp / oneway_plateau 다섯 엔진
+모두 동일한 구조를 가진다:
+  1) calculate_custom_score(G, ...)로 edge별 가중치 점수 부여
+  2) find_path(start, end, target_km)로 노드ID 경로 생성 (circular과 달리 3인자)
+  3) prune_dead_ends(nodes)로 왕복 잔가지 제거
+
+circular 버전(_circular_engine_common.py)과 동일한 이유로 engine.run() 대신
+좌표 변환 이전 단계(노드ID 경로)를 재현해서 사용한다 (엔진 알고리즘 자체는 안 건드림).
+"""
+
+import networkx as nx
+
+from src.route_engine.scoring.scoring_engine import calculate_custom_score
+
+
+def run_oneway_engine(engine, start_node: int, end_node: int, target_km: float) -> tuple[list, float]:
+    """OnewayXxxEngine 인스턴스에서 노드ID 경로와 누적 custom_score(cost)를 얻는다.
+
+    경로 생성에 실패하면(빈 경로/잔가지 제거 후 경로 소실) ValueError를 던진다 —
+    벤치마크 하네스가 이를 status="failed" 행으로 안전하게 처리한다.
+    """
+    calculate_custom_score(engine.G, {
+        "mode": engine.scoring_mode,
+        "weights": engine.weights,
+        "blocked_tags": engine.blocked_tags,
+    })
+
+    nodes = engine.find_path(start_node, end_node, target_km)
+    if not nodes or len(nodes) < 2:
+        raise ValueError("경로 생성 실패: 유효한 편도 경로를 찾지 못했습니다 (NO_PATH)")
+
+    pruned = engine.utils.prune_dead_ends(nodes)
+    if len(pruned) < 2:
+        raise ValueError("경로 생성 실패: 잔가지 제거 후 남은 경로가 없습니다")
+
+    _, cost = engine.utils.metrics(pruned)
+    return pruned, cost
+
+
+def base_shortest_path_overlap_ratio(engine, pruned_path: list, start_node: int, end_node: int) -> float:
+    """pruned_path가 베이스 최단경로(custom_score 기준)와 겹치는 구간의 거리 비율을 반환한다.
+
+    engine.G는 run_oneway_engine 호출 이후 이미 custom_score가 계산돼 있어야 한다.
+    Plateau처럼 '베이스 경로와 얼마나 안 겹치는가'가 알고리즘 핵심 지표인 solver에서 사용
+    (benchmark.py의 edge_overlap_ratio는 '자기 자신과의 왕복 중복'이라 다른 지표임).
+    """
+    try:
+        base_path = nx.shortest_path(engine.G, start_node, end_node, weight="custom_score")
+    except nx.NetworkXNoPath:
+        return 0.0
+
+    base_edges = {frozenset((base_path[i], base_path[i + 1])) for i in range(len(base_path) - 1)}
+
+    total_m = sum(
+        (engine.G.get_edge_data(pruned_path[i], pruned_path[i + 1]) or {}).get("length", 0)
+        for i in range(len(pruned_path) - 1)
+    )
+    if total_m <= 0:
+        return 0.0
+
+    overlap_m = sum(
+        (engine.G.get_edge_data(pruned_path[i], pruned_path[i + 1]) or {}).get("length", 0)
+        for i in range(len(pruned_path) - 1)
+        if frozenset((pruned_path[i], pruned_path[i + 1])) in base_edges
+    )
+    return round(overlap_m / total_m, 4)

--- a/benchmarks/solvers/plateau_solver.py
+++ b/benchmarks/solvers/plateau_solver.py
@@ -1,0 +1,39 @@
+"""
+benchmarks/solvers/plateau_solver.py
+
+src/route_engine/engines/oneway_plateau.py (Plateau method)를 BasePathSolver 규격으로
+감싸는 어댑터. oneway 전용(circular 미지원)이라 solver도 하나만 존재한다.
+
+overlap_ratio는 다른 solver들처럼 0.0 고정이 아니라, 베이스 최단경로와의 실제 중복
+비율을 계산해서 담는다 — "plateau 회피"가 이 알고리즘의 존재 이유이기 때문에,
+벤치마크 결과표에서 그 효과가 바로 드러나야 함.
+"""
+
+from benchmarks.solvers._oneway_engine_common import base_shortest_path_overlap_ratio, run_oneway_engine
+from benchmarks.solvers.base_solver import BasePathSolver
+from src.route_engine.engines.oneway_plateau import OnewayPlateauEngine
+from src.schema.route_schema import OnewayRouteInput
+
+_DEFAULT_TARGET_KM = 3.0
+
+
+class PlateauSolver(BasePathSolver):
+    def __init__(self, name: str = "Plateau"):
+        super().__init__(name)
+
+    def solve(self, graph, start_node, target_node, params: dict) -> dict:
+        target_km = params.get("target_km") or _DEFAULT_TARGET_KM
+        inp = OnewayRouteInput(
+            start_lat=0.0, start_lon=0.0, end_lat=0.0, end_lon=0.0, target_km=target_km,
+        )
+
+        engine = OnewayPlateauEngine(
+            inp=inp,
+            G=graph,
+            custom_weights=params.get("custom_weights"),
+            profile=params.get("profile"),
+        )
+        path, cost = run_oneway_engine(engine, start_node, target_node, target_km)
+        overlap_ratio = base_shortest_path_overlap_ratio(engine, path, start_node, target_node)
+
+        return {"paths": [path], "cost": cost, "overlap_ratio": overlap_ratio}

--- a/benchmarks/solvers/rcsp_solver.py
+++ b/benchmarks/solvers/rcsp_solver.py
@@ -1,0 +1,57 @@
+"""
+benchmarks/solvers/rcsp_solver.py
+
+src/route_engine/engines/circular_rcsp.py, oneway_rcsp.py (RCSP - 자원제약 최단경로)를
+BasePathSolver 규격으로 감싸는 어댑터. circular/oneway 둘 다 벤치마크 대상이라
+두 버전을 각각 제공한다 — oneway_rcsp가 Plateau(oneway 전용)와 직접 비교되는 대상.
+"""
+
+from benchmarks.solvers._circular_engine_common import run_circular_engine
+from benchmarks.solvers._oneway_engine_common import run_oneway_engine
+from benchmarks.solvers.base_solver import BasePathSolver
+from src.route_engine.engines.circular_rcsp import CircularRcspEngine
+from src.route_engine.engines.oneway_rcsp import OnewayRcspEngine
+from src.schema.route_schema import CircularRouteInput, OnewayRouteInput
+from benchmarks.solvers._oneway_engine_common import base_shortest_path_overlap_ratio
+
+_DEFAULT_TARGET_KM = 3.0
+
+
+class CircularRcspSolver(BasePathSolver):
+    def __init__(self, name: str = "RCSP(circular)"):
+        super().__init__(name)
+
+    def solve(self, graph, start_node, target_node, params: dict) -> dict:
+        target_km = params.get("target_km") or _DEFAULT_TARGET_KM
+        inp = CircularRouteInput(start_lat=0.0, start_lon=0.0, target_km=target_km)
+
+        engine = CircularRcspEngine(
+            inp=inp,
+            G=graph,
+            custom_weights=params.get("custom_weights"),
+            profile=params.get("profile"),
+        )
+        path, cost = run_circular_engine(engine, start_node, target_km)
+
+        return {"paths": [path], "cost": cost, "overlap_ratio": 0.0}
+
+
+class OnewayRcspSolver(BasePathSolver):
+    def __init__(self, name: str = "RCSP(oneway)"):
+        super().__init__(name)
+
+    def solve(self, graph, start_node, target_node, params: dict) -> dict:
+        target_km = params.get("target_km") or _DEFAULT_TARGET_KM
+        inp = OnewayRouteInput(
+            start_lat=0.0, start_lon=0.0, end_lat=0.0, end_lon=0.0, target_km=target_km,
+        )
+
+        engine = OnewayRcspEngine(
+            inp=inp,
+            G=graph,
+            custom_weights=params.get("custom_weights"),
+            profile=params.get("profile"),
+        )
+        path, cost = run_oneway_engine(engine, start_node, target_node, target_km)
+        overlap_ratio = base_shortest_path_overlap_ratio(engine, path, start_node, target_node)
+        return {"paths": [path], "cost": cost, "overlap_ratio": overlap_ratio}


### PR DESCRIPTION
## ☝️Issue Number
- resolve #291 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- BasePathSolver 규격에 맞춰 CircularRcspSolver·OnewayRcspSolver와 PlateauSolver를 추가하고 benchmark.py의 SOLVER_REGISTRY에 등록
- oneway 계열은 기존 _circular_engine_common.py와  시그니처가 달라 _oneway_engine_common.py를 추가
- base_shortest_path_overlap_ratio()로 베이스 최단경로 대비 실제 중복 비율을 계산해 overlap_ratio에 반영
- oneway 계열 CLI 실행을 위해 --end-node 옵션 추가(미지정 시 기존처럼 target_node=start_node로 순환 경로 동작 그대로 유지)
