### PR TITLE
[feat] alns, beam, grasp oneway solver 추가 및 benchmark.py 설정

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -42,11 +42,11 @@ import networkx as nx
 import pandas as pd
 
 from benchmarks.config import BENCH_DIR, ROUTE_EDGES_PARQUET, ROUTE_NODES_PARQUET
-from benchmarks.solvers.alns_solver import AlnsSolver
+from benchmarks.solvers.alns_solver import CircularAlnsSolver, OnewayAlnsSolver
 from benchmarks.solvers.base_solver import BasePathSolver
-from benchmarks.solvers.beam_solver import BeamSolver
+from benchmarks.solvers.beam_solver import CircularBeamSolver, OnewayBeamSolver
 from benchmarks.solvers.dummy_solver import DummySolver
-from benchmarks.solvers.grasp_solver import GraspSolver
+from benchmarks.solvers.grasp_solver import CircularGraspSolver, OnewayGraspSolver
 from benchmarks.solvers.plateau_solver import PlateauSolver
 from benchmarks.solvers.rcsp_solver import CircularRcspSolver, OnewayRcspSolver
 
@@ -66,9 +66,12 @@ QUEUE_FLUSH_GRACE_SEC = 5.0  # 자식 프로세스 종료 후 큐에 결과가 �
 
 # 벤치마크 대상 알고리즘 등록 지점.
 SOLVER_REGISTRY: dict[str, BasePathSolver] = {
-    "grasp": GraspSolver(),
-    "beam": BeamSolver(),
-    "alns": AlnsSolver(),
+    "grasp-circular": CircularGraspSolver(),    
+    "grasp-oneway": OnewayGraspSolver(),
+    "beam-circular": CircularBeamSolver(),
+    "beam-oneway" : OnewayBeamSolver(),
+    "alns-circular": CircularAlnsSolver(),
+    "alns-oneway": OnewayAlnsSolver(),
     "rcsp-circular": CircularRcspSolver(),
     "rcsp-oneway": OnewayRcspSolver(),
     "plateau": PlateauSolver(),

--- a/benchmarks/solvers/alns_solver.py
+++ b/benchmarks/solvers/alns_solver.py
@@ -5,15 +5,17 @@ src/route_engine/engines/circular_alns.py (ALNS)를 BasePathSolver 규격으로 
 """
 
 from benchmarks.solvers._circular_engine_common import run_circular_engine
+from benchmarks.solvers._oneway_engine_common import run_oneway_engine, base_shortest_path_overlap_ratio
 from benchmarks.solvers.base_solver import BasePathSolver
 from src.route_engine.engines.circular_alns import CircularAlnsEngine
-from src.schema.route_schema import CircularRouteInput
+from src.route_engine.engines.oneway_alns import OnewayAlnsEngine
+from src.schema.route_schema import CircularRouteInput, OnewayRouteInput
 
 _DEFAULT_TARGET_KM = 3.0
 _DEFAULT_SEED = 42
 
 
-class AlnsSolver(BasePathSolver):
+class CircularAlnsSolver(BasePathSolver):
     def __init__(self, name: str = "ALNS", seed: int = _DEFAULT_SEED):
         super().__init__(name)
         self.seed = seed
@@ -32,3 +34,26 @@ class AlnsSolver(BasePathSolver):
         path, cost = run_circular_engine(engine, start_node, target_km)
 
         return {"paths": [path], "cost": cost, "overlap_ratio": 0.0}
+
+class OnewayAlnsSolver(BasePathSolver):
+    def __init__(self, name: str = "ALNS(oneway)", seed: int = _DEFAULT_SEED):
+        super().__init__(name)
+        self.seed = seed
+
+    def solve(self, graph, start_node, target_node, params: dict) -> dict:
+        target_km = params.get("target_km") or _DEFAULT_TARGET_KM
+        inp = OnewayRouteInput(
+            start_lat=0.0, start_lon=0.0, end_lat=0.0, end_lon=0.0, target_km=target_km,
+        )
+
+        engine = OnewayAlnsEngine(
+            inp=inp,
+            G=graph,
+            custom_weights=params.get("custom_weights"),
+            profile=params.get("profile"),
+            seed=self.seed,
+        )
+        path, cost = run_oneway_engine(engine, start_node, target_node, target_km)
+        overlap_ratio = base_shortest_path_overlap_ratio(engine, path, start_node, target_node)
+
+        return {"paths": [path], "cost": cost, "overlap_ratio": overlap_ratio}

--- a/benchmarks/solvers/beam_solver.py
+++ b/benchmarks/solvers/beam_solver.py
@@ -6,14 +6,16 @@ src/route_engine/engines/circular_beam.py (Beam Search)를 BasePathSolver 규격
 """
 
 from benchmarks.solvers._circular_engine_common import run_circular_engine
+from benchmarks.solvers._oneway_engine_common import run_oneway_engine, base_shortest_path_overlap_ratio
 from benchmarks.solvers.base_solver import BasePathSolver
 from src.route_engine.engines.circular_beam import CircularBeamEngine
-from src.schema.route_schema import CircularRouteInput
+from src.route_engine.engines.oneway_beam import OnewayBeamEngine
+from src.schema.route_schema import CircularRouteInput, OnewayRouteInput
 
 _DEFAULT_TARGET_KM = 3.0
 
 
-class BeamSolver(BasePathSolver):
+class CircularBeamSolver(BasePathSolver):
     def __init__(self, name: str = "Beam"):
         super().__init__(name)
 
@@ -30,3 +32,24 @@ class BeamSolver(BasePathSolver):
         path, cost = run_circular_engine(engine, start_node, target_km)
 
         return {"paths": [path], "cost": cost, "overlap_ratio": 0.0}
+
+class OnewayBeamSolver(BasePathSolver):
+    def __init__(self, name: str = "Beam(oneway)"):
+        super().__init__(name)
+
+    def solve(self, graph, start_node, target_node, params: dict) -> dict:
+        target_km = params.get("target_km") or _DEFAULT_TARGET_KM
+        inp = OnewayRouteInput(
+            start_lat=0.0, start_lon=0.0, end_lat=0.0, end_lon=0.0, target_km=target_km,
+        )
+
+        engine = OnewayBeamEngine(
+            inp=inp,
+            G=graph,
+            custom_weights=params.get("custom_weights"),
+            profile=params.get("profile"),
+        )
+        path, cost = run_oneway_engine(engine, start_node, target_node, target_km)
+        overlap_ratio = base_shortest_path_overlap_ratio(engine, path, start_node, target_node)
+
+        return {"paths": [path], "cost": cost, "overlap_ratio": overlap_ratio}

--- a/benchmarks/solvers/grasp_solver.py
+++ b/benchmarks/solvers/grasp_solver.py
@@ -6,15 +6,17 @@ src/route_engine/engines/circular_grasp.py (GRASP + VNS)를 BasePathSolver 규�
 """
 
 from benchmarks.solvers._circular_engine_common import run_circular_engine
+from benchmarks.solvers._oneway_engine_common import run_oneway_engine, base_shortest_path_overlap_ratio
 from benchmarks.solvers.base_solver import BasePathSolver
 from src.route_engine.engines.circular_grasp import CircularGraspEngine
-from src.schema.route_schema import CircularRouteInput
+from src.route_engine.engines.oneway_grasp import OnewayGraspEngine
+from src.schema.route_schema import CircularRouteInput, OnewayRouteInput
 
 _DEFAULT_TARGET_KM = 3.0
 _DEFAULT_SEED = 42
 
 
-class GraspSolver(BasePathSolver):
+class CircularGraspSolver(BasePathSolver):
     def __init__(self, name: str = "GRASP+VNS", seed: int = _DEFAULT_SEED):
         super().__init__(name)
         self.seed = seed
@@ -33,3 +35,26 @@ class GraspSolver(BasePathSolver):
         path, cost = run_circular_engine(engine, start_node, target_km)
 
         return {"paths": [path], "cost": cost, "overlap_ratio": 0.0}
+
+class OnewayGraspSolver(BasePathSolver):
+    def __init__(self, name: str = "GRASP+VNS(oneway)", seed: int = _DEFAULT_SEED):
+        super().__init__(name)
+        self.seed = seed
+
+    def solve(self, graph, start_node, target_node, params: dict) -> dict:
+        target_km = params.get("target_km") or _DEFAULT_TARGET_KM
+        inp = OnewayRouteInput(
+            start_lat=0.0, start_lon=0.0, end_lat=0.0, end_lon=0.0, target_km=target_km,
+        )
+
+        engine = OnewayGraspEngine(
+            inp=inp,
+            G=graph,
+            custom_weights=params.get("custom_weights"),
+            profile=params.get("profile"),
+            seed=self.seed,
+        )
+        path, cost = run_oneway_engine(engine, start_node, target_node, target_km)
+        overlap_ratio = base_shortest_path_overlap_ratio(engine, path, start_node, target_node)
+
+        return {"paths": [path], "cost": cost, "overlap_ratio": overlap_ratio}


### PR DESCRIPTION
## ☝️Issue Number
- resolve #295 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 벤치마크 solver에 oneway 전용 `OnewayBeamSolver`/`OnewayGraspSolver`/`OnewayAlnsSolver`를 추가해, `rcsp-oneway`/`plateau`와 동일 조건(편도, start≠end)으로 공정 비교할 수 있게 함
- 기존 circular solver(`BeamSolver`/`GraspSolver`/`AlnsSolver`)는 `CircularBeamSolver`/`CircularGraspSolver`/`CircularAlnsSolver`로 이름을 바꿔 `rcsp_solver.py`의 Circular/Oneway 접두사 규칙과 통일함
- `SOLVER_REGISTRY`의 CLI 키를 전부 `-circular`/`-oneway` 접미사 규칙으로 통일 (`beam` → `beam-circular`/`beam-oneway`, `grasp` → `grasp-circular`/`grasp-oneway`, `alns` → `alns-circular`/`alns-oneway`. `plateau`는 oneway 전용이라 접미사 없이 유지)
- 실제로 신규/기존 solver 9종을 같은 입력(start=33475, end=125025, target_km=4.3)으로 돌려서 전부 `status: ok`(circular는 `is_closed_loop: True`) 확인함 — 리네이밍에 따른 회귀 없음

## 🔧 팀원 필수 작업
- `--algo` 옵션에 `beam`/`grasp`/`alns`(접미사 없는 옛 키)를 쓰던 스크립트나 문서가 있다면 `beam-circular`/`grasp-circular`/`alns-circular`로 교체 필요 (옛 키는 더 이상 존재하지 않음)
- `python -m benchmarks.benchmark --list`로 새 키 목록 먼저 확인 권장