### PR TITLE
[feat] 온보딩 설문 API — RN 앱 인증 지원 + 선택 태그 저장/반환

### DIFF
--- a/scripts/migrate_add_selected_tags.py
+++ b/scripts/migrate_add_selected_tags.py
@@ -1,0 +1,70 @@
+"""
+user_preferences 테이블에 selected_tags(JSON) 컬럼을 추가하는 일회성 마이그레이션 스크립트.
+
+배경:
+    온보딩 설문에서 유저가 선택한 원본 태그 배열을 마이페이지 등에서 하이라이트 표시하기 위해
+    계산된 weights 외에 selected_tags를 별도로 보존해야 함.
+
+실행:
+    미리보기(기본): poetry run python scripts/migrate_add_selected_tags.py
+    실제 적용     : poetry run python scripts/migrate_add_selected_tags.py --apply
+
+주의:
+    멱등하게 작성되어 있음 (컬럼이 이미 존재하면 건너뜀).
+    그래도 운영 DB에 적용 전 반드시 백업을 권장함.
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+load_dotenv(encoding="utf-8")
+
+from sqlalchemy import create_engine, text
+
+DB_URL = (
+    f"postgresql+psycopg2://"
+    f"{os.getenv('POSTGRES_USER')}:{os.getenv('POSTGRES_PASSWORD')}"
+    f"@{os.getenv('POSTGRES_HOST')}:{os.getenv('POSTGRES_PORT')}"
+    f"/{os.getenv('POSTGRES_DB')}?client_encoding=utf8"
+)
+
+engine = create_engine(DB_URL)
+
+CHECK_SQL = text("""
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name = 'user_preferences'
+      AND column_name = 'selected_tags'
+""")
+
+ALTER_SQL = text("""
+    ALTER TABLE user_preferences
+    ADD COLUMN selected_tags JSON NULL
+""")
+
+
+def main(apply: bool) -> None:
+    with engine.connect() as conn:
+        result = conn.execute(CHECK_SQL).fetchone()
+        if result is not None:
+            print("✅ selected_tags 컬럼이 이미 존재합니다. 건너뜁니다.")
+            return
+
+        if apply:
+            conn.execute(ALTER_SQL)
+            conn.commit()
+            print("✅ 적용 완료: user_preferences.selected_tags(JSON NULL) 컬럼 추가됨")
+        else:
+            print("[DRY-RUN] 실행 예정 SQL:")
+            print("  ALTER TABLE user_preferences ADD COLUMN selected_tags JSON NULL;")
+            print("\n실제로 반영하려면 --apply 를 붙여 다시 실행하세요.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="user_preferences.selected_tags 컬럼 추가 마이그레이션")
+    parser.add_argument("--apply", action="store_true", help="실제로 DB에 반영 (미지정 시 dry-run)")
+    main(parser.parse_args().apply)

--- a/src/entity/user_preference.py
+++ b/src/entity/user_preference.py
@@ -6,7 +6,7 @@ users 테이블과 1:1 관계이며, 설문 미완료 시 경로 추천은 기�
 """
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Boolean, Float, ForeignKey, Integer
+from sqlalchemy import JSON, Boolean, Float, ForeignKey, Integer
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.entity.base import Base
@@ -42,5 +42,6 @@ class UserPreference(Base):
     weights_running: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     weights_landmark: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     weights_child: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    selected_tags: Mapped[Optional[list[str]]] = mapped_column(JSON, nullable=True)
 
     user: Mapped["User"] = relationship("User", back_populates="user_preference")

--- a/src/interfaces/api/user_router.py
+++ b/src/interfaces/api/user_router.py
@@ -8,6 +8,7 @@ src/interfaces/api/user_router.py
 from typing import Optional
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import logging
 
 from src.interfaces.dependencies import get_survey_service, get_auth_service, get_user_service
@@ -24,6 +25,16 @@ from src.service.user.auth_service import AuthService
 from src.interfaces.schema.auth_schema import Status
 
 logger = logging.getLogger(__name__)
+
+optional_bearer = HTTPBearer(auto_error=False)
+
+
+def _resolve_token(
+    credentials: HTTPAuthorizationCredentials | None,
+    cookie_token: str | None,
+) -> str | None:
+    return (credentials.credentials if credentials else None) or cookie_token
+
 
 router = APIRouter(prefix="/api/user", tags=["user"])
 
@@ -54,10 +65,11 @@ def update_me(
 @router.post("/survey", response_model=SurveyResponse)
 def submit_survey(
     request: SurveyRequest,
-    access_token: str = Cookie(None),
+    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
+    cookie_token: str = Cookie(None, alias="access_token"),
     service: SurveyService = Depends(get_survey_service),
 ):
-    return service.submit(access_token, request)
+    return service.submit(_resolve_token(credentials, cookie_token), request)
 
 
 @router.get("/routes", response_model=RouteHistoryResponse)
@@ -163,8 +175,9 @@ def get_route_history(
 
 @router.get("/survey", response_model=SurveyStatusResponse)
 def get_survey_status(
-    access_token: str = Cookie(None),
+    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
+    cookie_token: str = Cookie(None, alias="access_token"),
     service: SurveyService = Depends(get_survey_service),
 ):
     """설문 완료 여부를 반환합니다."""
-    return service.get_status(access_token)
+    return service.get_status(_resolve_token(credentials, cookie_token))

--- a/src/interfaces/schema/survey_schema.py
+++ b/src/interfaces/schema/survey_schema.py
@@ -62,3 +62,4 @@ class SurveyStatusResponse(BaseModel):
     weights_running: Optional[float] = None
     weights_landmark: Optional[float] = None
     weights_child: Optional[float] = None
+    selected_tags: Optional[List[str]] = None

--- a/src/service/user/survey_service.py
+++ b/src/service/user/survey_service.py
@@ -115,6 +115,7 @@ class SurveyService:
             weights_running=weights.get("running"),
             weights_landmark=weights.get("landmark"),
             weights_child=weights.get("child"),
+            selected_tags=request.tags if request.tags else None,
         )
 
         return SurveyResponse(
@@ -151,4 +152,5 @@ class SurveyService:
             weights_running=preference.weights_running,
             weights_landmark=preference.weights_landmark,
             weights_child=preference.weights_child,
+            selected_tags=preference.selected_tags,
         )


### PR DESCRIPTION
## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
---
### 배경

온보딩 설문과 관련된 두 가지 문제가 있었습니다.

- *문제 1 — RN 앱에서 설문 API 인증 실패*

서버는 이미 Authorization: Bearer <token> 헤더 방식으로 인증을 마이그레이션해 RN 앱에서 사용 중인데, 설문 엔드포인트(GET/POST /api/user/survey)만 쿠키(Cookie: access_token=...) 방식으로만 인증을 받고 있었습니다. 그 결과 RN 앱에서 설문을 제출하거나 완료 여부를 조회할 때 항상 인증 실패가 발생했습니다.

- *문제 2 — 선택한 태그를 마이페이지에서 보여줄 수 없음*

설문 제출 시 선택한 태그(["나무 많은", "큰길"] 등)가 경로 가중치(숫자값)로 변환되어 저장될 뿐, 원본 태그 배열 자체는 저장되지 않았습니다. 마이페이지에서 "내가 선택했던 태그"를 하이라이트로 보여주려면 원본 선택값이 필요합니다.

---
### 변경 내용

*1. 설문 API 인증 방식 확장 — 헤더 + 쿠키 동시 지원*

변경 파일: src/interfaces/api/user_router.py

GET /api/user/survey, POST /api/user/survey 두 엔드포인트의 인증 방식을 변경했습니다.

- 변경 전: Cookie: access_token=... 방식만 지원
- 변경 후: Authorization: Bearer <token> 헤더와 쿠키 둘 다 지원. 헤더가 있으면 헤더 우선, 없으면 쿠키로 fallback

RN 앱   → Authorization: Bearer <token>  ✅ 이제 동작
Streamlit → Cookie: access_token=...     ✅ 그대로 동작

구현 방식은 이미 auth_router.py에서 쓰고 있는 HTTPBearer(auto_error=False) 패턴을 그대로 따랐고, _resolve_token() 헬퍼로 토큰 추출 로직을 분리했습니다.

---
*2. 선택 태그 원본 저장 및 반환*

변경 파일 4개 + 신규 스크립트 1개

① DB 컬럼 추가 (src/entity/user_preference.py)

user_preferences 테이블에 selected_tags 컬럼을 추가했습니다. JSON 타입, nullable입니다. 태그를 선택하지 않은 기존 유저의 데이터에는 영향을 주지 않습니다.

user_preferences 테이블
├── weights_safety, weights_nature, ...  (기존 — 계산된 가중치 숫자)
└── selected_tags  (신규 — ["나무 많은", "큰길"] 형태의 원본 배열)

② 설문 제출 시 태그 저장 (src/service/user/survey_service.py)

POST /api/user/survey 처리 시 가중치 계산 로직은 그대로 두고, 클라이언트가 보낸 태그 배열을 selected_tags에 함께 저장합니다. 빈 배열([])은 null로 저장합니다.

③ 설문 조회 시 태그 반환 (src/interfaces/schema/survey_schema.py, survey_service.py)

GET /api/user/survey 응답에 selected_tags 필드를 추가했습니다. 설문 미완료 유저는 null로 반환됩니다.

// GET /api/user/survey 응답 (변경 후)
{
  "survey_completed": true,
  "weights_safety": 0.7,
  "weights_nature": 0.2,
  ...
  "selected_tags": ["나무 많은", "큰길", "야경이 예쁜"]  // 신규
}

④ DB 마이그레이션 스크립트 (scripts/migrate_add_selected_tags.py)

기존 migrate_weights_baseline.py와 동일한 패턴으로 작성했습니다. 컬럼이 이미 존재하면 자동으로 건너뛰어 멱등하게 동작합니다.

# dry-run (미리보기)
poetry run python scripts/migrate_add_selected_tags.py

# 실제 적용
poetry run python scripts/migrate_add_selected_tags.py --apply

---
### 변경 파일 목록

파일: src/interfaces/api/user_router.py
구분: 수정
변경 요약: survey 엔드포인트 인증 — 쿠키 전용 →
  헤더+쿠키 겸용
────────────────────────────────────────
파일: src/entity/user_preference.py
구분: 수정
변경 요약: selected_tags JSON 컬럼 추가
────────────────────────────────────────
파일: src/interfaces/schema/survey_schema.py
구분: 수정
변경 요약: SurveyStatusResponse에 selected_tags
  필드 추가
────────────────────────────────────────
파일: src/service/user/survey_service.py
구분: 수정
변경 요약: 태그 저장(submit) + 태그
  반환(get_status)
────────────────────────────────────────
파일: scripts/migrate_add_selected_tags.py
구분: 신규
변경 요약: ALTER TABLE ADD COLUMN selected_tags
  JSON NULL 마이그레이션

---
### 배포 시 주의사항

코드 배포 전 또는 직후에 마이그레이션 스크립트를 반드시 실행해야 합니다. 스크립트 실행 전에는 selected_tags 컬럼이 없어 서버가 기동 시 오류를 낼 수 있습니다.