### PR TITLE
[Docs] 챗봇 하드코딩 문구 처리 내역 반영

### DIFF
--- a/docs/chatbot/agent_harness.md
+++ b/docs/chatbot/agent_harness.md
@@ -1,9 +1,9 @@
 # 챗봇 Agent 하네스
 
 > 상태: Current  
-> 기준일: 2026-07-30
+> 기준일: 2026-07-30  
 > 관련 코드: `src/agent/`, `src/service/chat/prewalk_service.py`, `src/schema/prewalk_schema.py`  
-> 검증 상태: 현재 코드 대조·프로필 전달 단위 테스트 완료·기존 격리 통합 확인
+> 검증 상태: 코드 정적 대조 완료(2026-07-30, `ConfirmationClassifier` 추가·Graph 재배선·dev PR #310 profile/nearby_pois 반영) + `ConfirmationClassifier`·조건부 진입점 실행 검증 완료(2026-07-30, 로컬 PostgreSQL·Valkey·실제 Kakao·OpenAI, 프런트엔드 연동 안드로이드 기기 테스트). profile/nearby_pois(dev PR #310)는 정적 대조만 했고 격리 환경 실행 검증은 별도로 안 함
 
 ## 1. 책임
 
@@ -34,8 +34,8 @@ HTTP 입력:
 | `destination_candidate` | `Interviewer` | 다음 `Interviewer`(첫 번째 후보 자동 확정용) |
 | `themes` | `Extractor` | `RouteExecutor` 가중치 |
 | `profile` | API State 또는 `RouteExecutor` | 명시값 우선, 없으면 테마에서 결정 |
-| `awaiting_confirmation` | `Interviewer`·Orchestrator | 다음 intent 분기 |
-| `is_complete` | `Interviewer`·Orchestrator | Graph 분기·완료 상태 |
+| `awaiting_confirmation` | `Interviewer`(True로 설정)·`ConfirmationClassifier`(False로 해제) | 다음 intent의 Graph 진입점 분기(`ConfirmationClassifier` vs `Extractor`) |
+| `is_complete` | `Interviewer`·`ConfirmationClassifier` | Graph 분기(`RouteExecutor` 진입 여부)·완료 상태 |
 | `response` | 각 대화 Node·Orchestrator | `ChatResponse.state` |
 | `route_result` | `RouteExecutor` | API 응답·Valkey 저장 |
 
@@ -54,7 +54,7 @@ HTTP 입력:
 - Valkey: `chat_state:{thread_id}`에 전체 State JSON 저장, TTL 3,600초
 - 경로 성공: `RouteService`가 `RouteHistory`를 저장하고 `route_result.id` 반환
 - 경로 성공: 경로 50m 안의 도보망 연결 POI를 `route_result.nearby_pois`로 반환
-- LLM 출력: 초기 인사, 모드·거리·위치·테마 추출, 누락 질문
+- LLM 출력: 초기 인사, 모드·거리·위치·테마 추출, 누락 질문, 확인 질문 긍정·부정 판정
 
 현재 intent State에는 access JWT가 포함되며 API 응답과 Valkey JSON 양쪽으로 전달된다. `ChatSession.current_state`는 경로 완료 후에도 `START`로 남는다.
 
@@ -68,6 +68,7 @@ src/agent/
 │   ├── weather_checker.py      # init 환경 인사, Graph 밖에서 실행
 │   ├── extractor.py            # 모드·위치·거리·테마 추출
 │   ├── interviewer.py          # 누락 질문·장소 검색·확인 질문
+│   ├── confirmation_classifier.py  # 확인 질문에 대한 긍정/부정 LLM 판정
 │   └── route_executor.py       # 가중치 조합·경로 실행
 ├── tools/
 │   ├── mode_tools.py           # preference 생성
@@ -93,6 +94,7 @@ src/prompt/                                      # LLM Prompt
 | `WeatherChecker.run` | `lat`, `lon` | `init_message`(문자열) | 기상청·에어코리아·OpenAI |
 | `Extractor.run` | `State` | `mode`, `user_context`, `themes` | OpenAI, `ModeTool` |
 | `Interviewer.run` | `State` | 후보 위치, 보완된 context, `response`, 확인 상태 | OpenAI, `PlaceTool` |
+| `ConfirmationClassifier.run` | `State` | `is_complete`(긍정/부정 판정 결과), `awaiting_confirmation=False` | OpenAI(`PydanticOutputParser`, tool 미바인딩) |
 | `RouteExecutor.run` | `State` | `profile`, `route_result` | 사용자 설문, `RouteTool` |
 
 모든 대화 Node는 전달받은 State 객체를 변경해 반환한다. Node별 별도 입출력 schema는 없다.
@@ -105,23 +107,31 @@ flowchart TD
     WC --> SAVE["ChatSession + 초기 State 저장"]
 
     INTENT["POST /intent"] --> LOAD["인증 + State 조회 + 소유권 확인"]
-    LOAD --> AWAIT{"awaiting_confirmation?"}
-    AWAIT -- "아니오" --> EX["Extractor"]
-    EX --> IV["Interviewer"]
-    IV --> DECLARED{"선언 Edge: is_complete?"}
-    DECLARED -- "false: 현재 실행 경로" --> END1["State 저장·응답"]
-    DECLARED -. "true: 선언돼 있으나 현재 Interviewer가 만들지 않음" .-> RE["RouteExecutor"]
+    LOAD --> ENTRY{"조건부 진입점: awaiting_confirmation?"}
+    ENTRY -- "false" --> EX["Extractor"]
+    ENTRY -- "true" --> CC["ConfirmationClassifier"]
 
-    AWAIT -- "예" --> POS{"긍정 응답?"}
-    POS -- "긍정" --> RE
-    POS -- "부정·수정" --> END1
+    EX --> IV["Interviewer"]
+    IV --> DECLARED{"is_complete?"}
+    DECLARED -- "false" --> END1["State 저장·응답"]
+    DECLARED -- "true" --> RE["RouteExecutor"]
+
+    CC --> CDECIDE{"is_complete(판정 결과)?"}
+    CDECIDE -- "true: 긍정" --> RE
+    CDECIDE -- "false: 부정" --> EX
+
     RE --> RH["RouteService + RouteHistory"]
     RH --> END1
 ```
 
-Graph 선언은 `Extractor → Interviewer → (is_complete ? RouteExecutor : END)`다. 현재 `Interviewer`는 정보가 충분하면 `awaiting_confirmation=True`, `is_complete=False`로 반환하므로 Graph 안의 `RouteExecutor` Edge는 실행되지 않는다. 긍정 확인 턴에서 Orchestrator가 Graph를 우회해 직접 호출한다.
+Graph 선언은 조건부 진입점(`awaiting_confirmation` 기준)에서 시작한다.
 
-Git 이력 기준으로 조건부 Edge는 `0ed8073b`에서 추가됐다. `e42c36d`에서 경로 생성 전 확인 단계가 추가되며 `Interviewer`가 `awaiting_confirmation=True`, `is_complete=False`로 종료하고 다음 긍정 응답에서 Orchestrator가 `RouteExecutor`를 직접 호출하도록 바뀌었지만, 기존 조건부 Edge는 제거되지 않았다.
+- `awaiting_confirmation=False` → `Extractor → Interviewer → (is_complete ? RouteExecutor : END)`
+- `awaiting_confirmation=True` → `ConfirmationClassifier → (is_complete ? RouteExecutor : Extractor)`
+
+`Interviewer`는 정보가 충분하면 `awaiting_confirmation=True`, `is_complete=False`로 확인 질문을 만들고 END로 끝난다. 다음 intent 턴에서 조건부 진입점이 이를 보고 `ConfirmationClassifier`로 보낸다. `ConfirmationClassifier`는 `confirmation.yaml`(`PydanticOutputParser`, tool 미바인딩)로 긍정/부정을 LLM 판정해 `is_complete`에 그대로 반영하고 `awaiting_confirmation`을 해제한다. 부정 판정이면 `Interviewer`로 바로 가지 않고 `Extractor`를 다시 거치는데, 부정 응답에 수정 정보가 섞여 있을 수 있어서다("아니, 5km로 바꿔줘"의 "5km"는 `Interviewer`가 아니라 `Extractor`의 `ModeTool`만 파싱 가능).
+
+이전에는(2026-07-29 이전) `Interviewer`가 정보 충분 시 만든 `awaiting_confirmation=True` 상태를 Orchestrator가 Python if/else로 직접 처리하며 Graph 자체를 우회했고(긍정 시 `route_executor.run()` 직접 호출, 부정 시 하드코딩 문구 반환), 그래서 Graph에 선언된 조건부 Edge가 실행되지 않는 죽은 코드였다. 2026-07-30 `ConfirmationClassifier` 도입과 함께 이 우회 코드를 제거하고 확인 판정 자체를 Graph 안의 정식 Node·조건부 Edge로 옮겼다(근거: [챗봇 하드코딩 문구 처리 방안 제안](../proposals/chatbot_hardcoding_proposal.md) 1, 3번 항목).
 
 ### Tool과 Prompt
 
@@ -136,6 +146,7 @@ Git 이력 기준으로 조건부 Edge는 `0ed8073b`에서 추가됐다. `e42c36
 | `WeatherChecker` | `weather_checker.yaml` |
 | `Extractor` | `extraction.yaml`, `themes.yaml` |
 | `Interviewer` | `interview.yaml`(도구 바인딩 1차 호출 + 검색 결과 반영용 2차 재호출, 2차는 도구 미바인딩) |
+| `ConfirmationClassifier` | `confirmation.yaml`(도구 미바인딩, `PydanticOutputParser`로 `ConfirmationResult.is_positive` 파싱) |
 | `RouteExecutor` | 없음 |
 
 ## 5. 의존하는 영역
@@ -159,8 +170,8 @@ Git 이력 기준으로 조건부 Edge는 `0ed8073b`에서 추가됐다. `e42c36
 | 변경 | 함께 확인할 대상 |
 |---|---|
 | State 필드 | API schema, Valkey 기존 JSON, 모든 Node, 직렬화 |
-| Node 입출력 | Graph Edge, Orchestrator 직접 호출, Prompt |
-| 확인 상태 | 긍정·부정 단어 판정, `is_complete`, RouteExecutor 진입 |
+| Node 입출력 | Graph Edge, 조건부 진입점, Prompt |
+| 확인 상태 | `ConfirmationClassifier` LLM 판정(`confirmation.yaml`), `is_complete`, Graph 조건부 Edge, RouteExecutor 진입 |
 | Mode/Preference | ModeTool, Extractor prompt, Interviewer 완료 조건, RouteTool |
 | 장소 필드 | Kakao schema, 후보 선택, 서울 bbox 검증 |
 | 가중치·테마 | 설문 `TAG_WEIGHT_MAP`, `Weights`, 경로 scoring |
@@ -177,6 +188,7 @@ Git 이력 기준으로 조건부 Edge는 `0ed8073b`에서 추가됐다. `e42c36
 | 타 사용자 State | `unaccessible` | 자신의 thread 사용 |
 | Extractor LLM 실패 | 기존 State 유지 | 다음 intent에서 재시도 |
 | Interviewer LLM 실패 | fallback 문장 | 다음 intent에서 재시도 |
+| ConfirmationClassifier LLM 실패 | `is_complete=False`로 처리해 `Extractor`로 진행(안전 측 기본값, 별도 fallback 문구 없음) | 다음 intent에서 재확인 질문 재생성 |
 | RouteTool 실패 | 예외를 기록하고 기존 State 유지 | 조건 확인 후 재확인 |
 | State 저장 실패 | 응답은 반환될 수 있음 | Valkey 복구 후 init 재시작 |
 
@@ -184,23 +196,35 @@ HTTP 200만으로 성공을 판단하지 않는다. `status`, `awaiting_confirma
 
 ## 9. 검증 방법
 
-2026-07-27 격리 PostgreSQL·Valkey와 실제 Kakao·OpenAI·경로 엔진으로 다음을 확인했다.
+**2026-07-27 (Orchestrator 우회 방식 기준, 격리 PostgreSQL·Valkey + 실제 Kakao·OpenAI·경로 엔진)**
+
+이 실행 증거는 `ConfirmationClassifier` 도입 이전 구조 기준이라, 아래 관측값은 대화 흐름 자체(정보 수집·확인 대기)의 근거로만 유효하다.
 
 - init → ChatSession 1건, Valkey TTL 3,600초
 - 없는 thread → `session_not_found`
 - 타 사용자 thread → `unaccessible`
 - 발화 → 순환 모드·거리 추출 → 확인 대기
-- 긍정 확인 → 당시 격리 실행에서 61좌표·3.10km 경로와 RouteHistory 저장 관측
+- 긍정 확인 → 당시 격리 실행(Orchestrator 우회 방식)에서 61좌표·3.10km 경로와 RouteHistory 저장 관측
 - 경로 완료 State에 `is_complete=True`, PostgreSQL 세션은 `START`
 
 위 경로 좌표 수와 거리는 2026-07-27 일회성 관측값이며 고정 회귀 기대값이 아니다. 재현 조건과 상세 결과는 [챗봇 경로 추천 Workflow](../architecture/workflows/prewalk_conversation.md)에서 관리한다.
+
+**2026-07-30 (현재 Graph 구조, 로컬 PostgreSQL·Valkey + 실제 Kakao·OpenAI, 프런트엔드 연동 안드로이드 기기)**
+
+격리된 일회성 환경이 아니라 로컬 개발 DB·Valkey를 그대로 사용한 실행 확인이다. 다음을 확인했다:
+
+- 확인 질문에 긍정 응답 → `ConfirmationClassifier`가 긍정 판정 → `RouteExecutor` 진입까지 정상 동작
+- 확인 질문에 부정 + 수정 정보(예: "아니, Nkm로 바꿔줘") 응답 → `ConfirmationClassifier`가 부정 판정 → `Extractor`로 재진입해 수정 정보 반영까지 정상 동작
+- `awaiting_confirmation` 값에 따라 조건부 진입점이 `confirmation_classifier`/`extractor`로 정확히 분기함
+
+**아직 확인 안 된 항목**: `confirmation.yaml` 프롬프트가 애매한 응답(명시적 긍/부정 단어가 없는 경우)을 얼마나 잘 판정하는지, `ConfirmationClassifier` LLM 호출 실패 시 fallback 동작(`is_complete=False` 처리), 격리된(공유 상태 없는) 환경에서의 재현. 인증·세션·소유권 실패 경로는 이번 확인 범위에 포함되지 않았다.
 
 `tests/integration/test_api.py`는 router를 mock Orchestrator로 확인한다. 현재 실제 Node·Edge·State 저장·LLM tool call을 자동 검증하는 챗봇 전용 테스트는 없다.
 
 ## 10. 완료 기준
 
 - 파일·State·Node·Edge·Tool 표가 현재 코드와 일치한다.
-- 선언 Graph와 Orchestrator 우회 경로를 구분한다.
+- 선언 Graph가 실제 실행 경로와 일치한다(2026-07-30 기준 Orchestrator 우회 코드 제거됨).
 - State 작성자·소비자·저장소가 추적 가능하다.
 - 정상 대화와 인증·세션·소유권 실패를 실행 증거로 확인한다.
 - 변경 시 영향 대상과 복구 시작점을 찾을 수 있다.


### PR DESCRIPTION
## ☝️Issue Number
- resolve #312 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- `docs/chatbot/agent_harness.md`(챗봇 Agent 하네스 Current 문서)를 최신 코드 기준으로 갱신
  - `ConfirmationClassifier` 노드 추가, LangGraph 조건부 진입점 재배선(`refactor/309`/PR #311) 반영: State 표, 파일 구조, Node/Prompt 표, Edge 다이어그램, 영향 범위·실패 복구 표 갱신
  - Orchestrator가 Graph를 우회하던 기존 로직 서술을 제거하고, 조건부 Edge 기반 실제 실행 경로로 교체
