### PR TITLE
feat: 배포용 도보 Graph artifact 빌드

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ tests/
 # 로컬 Poetry 환경 설정과 경로 API 테스트 결과는 버전 관리하지 않습니다.
 /poetry.toml
 /route_test*.json
+/artifacts/walk_graph_*.pkl
+/artifacts/walk_graph_*.manifest.json
+/artifacts/walk_graph_*.sha256
+/artifacts/roudi_walk_graph_*.zip
 
 # 도보 네트워크 원본 파일은 제외하되, 코드 정의·출처 메타데이터는 버전 관리합니다.
 !src/data/raw/

--- a/docs/architecture/workflows/server_startup.md
+++ b/docs/architecture/workflows/server_startup.md
@@ -2,7 +2,7 @@
 
 > 상태: Current
 > 기준일: 2026-07-30
-> 관련 코드: `src/main.py`, `src/entity/base.py`, `src/interfaces/dependencies.py`, `src/repository/network/graph_repository.py`
+> 관련 코드: `src/main.py`, `src/entity/base.py`, `src/interfaces/dependencies.py`, `src/repository/network/graph_repository.py`, `src/repository/network/graph_artifact_repository.py`
 > 검증 상태: 개발 DB 실데이터 Graph·루트 API·직접 경로 확인
 
 ## 1. 목적과 시작 조건
@@ -15,16 +15,15 @@ FastAPI가 요청을 받기 전에 schema, 기본 배너, 메모리 Graph와 경
 |---|---|
 | `src.main:lifespan()` | startup 순서 |
 | `init_db()` | Entity 등록·schema 동기화·배너 seed |
-| `init_route_service()` | Graph와 서비스 생성 |
+| `init_route_service()` | 환경 설정에 따라 Graph를 선택하고 서비스 생성 |
 | `GraphRepository.load_graph()` | DB 도보망을 NetworkX Graph로 변환 |
+| `GraphArtifactRepository.load()` | 배포 artifact 검증·재로드 |
 
 ## 3. 정상 흐름
 
 ```text
-로깅
-→ init_db
-→ DB NODE·LINK·Score·POI 집계 조회
-→ NetworkX Graph 생성
+개발: WALK_GRAPH_SOURCE=database → DB에서 Graph 생성
+배포: WALK_GRAPH_SOURCE=artifact → 빌드된 Graph 검증·로드
 → RouteService·PrewalkOrchestrator 생성
 → API 요청 수신
 ```
@@ -36,6 +35,8 @@ DB 변경은 실행 중 Graph에 자동 반영되지 않으므로 재적재 후 
 2026-07-30 개발 DB startup에서 DB Graph 214,241 Node·277,331 Edge를 읽었고, 최대 연결 컴포넌트와 막다른 길 제거 후 160,188 Node·223,664 Edge를 서비스에 전달했다.
 
 `GET /`과 인증된 `POST /api/walk/route`가 성공했다.
+
+2026-07-30 Windows·Python 3.12.13·NetworkX 3.6 시험 빌드에서 같은 서비스 Graph를 64.1MiB `pkl`로 저장했다. DB Graph 생성·저장·재로드는 59.0초, 파일만 검증·재로드하는 데는 2.402초가 걸렸다. 이 결과는 미커밋 코드의 `source_dirty=true` 시험본이므로 배포 인계본으로 사용하지 않는다.
 
 ## 5. 실패·복구
 
@@ -50,4 +51,4 @@ DB 변경은 실행 중 Graph에 자동 반영되지 않으므로 재적재 후 
 
 ## 6. 남은 배포 검증
 
-현재 startup은 인스턴스마다 전체 Graph를 DB에서 다시 만든다. 배포용 Graph artifact 빌드·로드, 로드 시간, 컨테이너 메모리와 Cloud Run cold start는 별도 배포 작업에서 검증한다.
+배포용 Graph 빌드·검증 로더와 로컬 시험은 완료됐다. 커밋 후 최종 artifact 재생성, 컨테이너 메모리와 Cloud Run cold start는 배포 인계 시 검증한다.

--- a/docs/data/walk_network_contract.md
+++ b/docs/data/walk_network_contract.md
@@ -45,7 +45,7 @@ Point를 WalkNode로 만들거나, 유효하지 않은 Line을 임의로 복원�
 
 ## 5. Graph 생성
 
-`GraphRepository.load_graph()`는 다음 순서로 서비스 Graph를 만든다.
+개발 모드의 `GraphRepository.load_graph()`는 다음 순서로 서비스 Graph를 만든다.
 
 ```text
 보행 가능한 NODE·LINK 조회
@@ -53,6 +53,16 @@ Point를 WalkNode로 만들거나, 유효하지 않은 Line을 임의로 복원�
 → 최대 연결 컴포넌트 선택
 → 막다른 노드 제거
 ```
+
+배포용 Graph는 이 최종 결과를 `GraphArtifactRepository`로 직렬화한다.
+
+```text
+walk_graph_v1.pkl
++ walk_graph_v1.manifest.json
++ walk_graph_v1.sha256
+```
+
+`WALK_GRAPH_SOURCE=artifact`이면 서버는 DB에서 NODE·LINK를 다시 조립하지 않고 artifact의 데이터 버전, 선택적 생성 커밋, schema, Python·NetworkX 버전, 노드·엣지 수와 SHA-256을 검증한 뒤 로드한다. 미커밋 코드에서 만든 artifact와 변조된 파일은 배포 모드에서 거부한다.
 
 DB 변경 후 실행 중 Graph는 자동 갱신되지 않으므로 서버를 재시작한다.
 
@@ -69,6 +79,8 @@ DB 변경 후 실행 중 Graph는 자동 갱신되지 않으므로 서버를 재
 - 보행 불가 LINK 제외
 - 연결 POI의 `nearest_edge_id` 무결성
 - DB Graph에서 대표 경로 생성 성공
+- artifact 저장 후 재로드한 Graph의 노드·엣지 수 일치
+- manifest와 checksum의 SHA-256 일치
 
 ## 8. 완료 기준
 

--- a/docs/operations/data_rebuild.md
+++ b/docs/operations/data_rebuild.md
@@ -121,7 +121,40 @@ SELECT
 
 관측 건수는 [V1 데이터 적재 Workflow](../architecture/workflows/v1_data_ingestion.md)를 참고하되 고정 상수로 사용하지 않는다.
 
-## 6. 실패·복구
+## 6. 배포용 도보 Graph 빌드
+
+DB 재구축과 공통 검증이 끝난 뒤 배포팀에 전달할 Graph를 만든다. 최종 artifact는 커밋된 코드에서만 생성한다.
+
+```bash
+./.venv/Scripts/python.exe -m scripts.build_walk_graph
+```
+
+로컬 구현 중 시험 빌드만 다음 옵션을 허용한다. 이 결과는 배포 로더가 거부하므로 전달하지 않는다.
+
+```bash
+./.venv/Scripts/python.exe -m scripts.build_walk_graph --allow-dirty
+```
+
+출력:
+
+```text
+artifacts/walk_graph_v1.pkl
+artifacts/walk_graph_v1.manifest.json
+artifacts/walk_graph_v1.sha256
+```
+
+빌더는 DB의 최종 서비스 Graph를 저장한 뒤 다시 로드하여 노드·엣지 수와 SHA-256을 검증한다. 세 파일을 함께 압축해 Drive로 전달하며 Git에는 커밋하지 않는다.
+
+배포팀은 세 파일을 `artifacts/`에 배치하고 다음 환경변수를 설정한다.
+
+```text
+WALK_GRAPH_SOURCE=artifact
+WALK_GRAPH_ARTIFACT_PATH=artifacts/walk_graph_v1.pkl
+WALK_GRAPH_DATA_VERSION=v1-2026-07-30
+WALK_GRAPH_EXPECTED_COMMIT={manifest의 source_commit, 선택}
+```
+
+## 7. 실패·복구
 
 | 실패 | 복구 시작점 |
 |---|---|
@@ -129,13 +162,15 @@ SELECT
 | NODE·LINK transaction | rollback 확인 후 `rebuild` |
 | 후속 Layer·Score | 실패 Collector 재실행 |
 | POI 공간 쿼리 장기 실행 | DB 쿼리 취소, geography 인덱스 생성 후 POI 재실행 |
+| Graph artifact 검증 실패 | 세 파일의 버전·SHA-256 확인 후 같은 커밋에서 재빌드 |
 | DB 성공·서버 실패 | DB 유지, 서버 시작 오류 수정 후 재시작 |
 | 새 데이터 전체 폐기 | 확인된 백업으로 복원 |
 
-## 7. 완료 기준
+## 8. 완료 기준
 
 - 대상과 백업 정책이 확인됐다.
 - 모든 V1 Collector가 완료됐다.
 - DB 참조 무결성과 건수를 확인했다.
 - Graph 재로딩과 대표 경로가 성공했다.
+- 배포 artifact 세 파일을 같은 커밋에서 생성·검증했다.
 - 실행 결과를 Workflow에 기록했다.

--- a/scripts/build_walk_graph.py
+++ b/scripts/build_walk_graph.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+import time
+from pathlib import Path
+
+from src.repository.network.graph_artifact_repository import GraphArtifactRepository
+from src.repository.network.graph_repository import GraphRepository
+
+
+logger = logging.getLogger(__name__)
+
+
+def _git_state() -> tuple[str, bool]:
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        dirty = bool(
+            subprocess.run(
+                ["git", "status", "--porcelain"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        )
+        return commit, dirty
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        raise SystemExit(f"Git 기준 커밋을 확인할 수 없습니다: {exc}") from exc
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="현재 PostgreSQL 도보망으로 배포용 NetworkX Graph를 빌드합니다."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts/walk_graph_v1.pkl"),
+        help="생성할 .pkl 경로",
+    )
+    parser.add_argument(
+        "--data-version",
+        default="v1-2026-07-30",
+        help="manifest에 기록할 데이터 기준 버전",
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="로컬 검증용으로만 미커밋 코드에서 빌드를 허용합니다.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(levelname)s] [%(name)s] %(message)s",
+    )
+
+    source_commit, source_dirty = _git_state()
+    if source_dirty and not args.allow_dirty:
+        raise SystemExit(
+            "작업 트리에 미커밋 변경이 있습니다. 최종 배포 artifact는 코드를 "
+            "커밋한 뒤 빌드하세요. 로컬 검증만 할 때는 --allow-dirty를 사용합니다."
+        )
+
+    started_at = time.perf_counter()
+    logger.info("PostgreSQL에서 최종 서비스 Graph를 생성합니다.")
+    graph = GraphRepository.load_graph()
+    manifest = GraphArtifactRepository.save(
+        graph,
+        args.output,
+        data_version=args.data_version,
+        source_commit=source_commit,
+        source_dirty=source_dirty,
+    )
+    loaded_graph = GraphArtifactRepository.load(
+        args.output,
+        allow_dirty=args.allow_dirty,
+    )
+    if (
+        loaded_graph.number_of_nodes() != graph.number_of_nodes()
+        or loaded_graph.number_of_edges() != graph.number_of_edges()
+    ):
+        raise SystemExit("저장 후 재로드한 Graph 건수가 원본과 다릅니다.")
+    elapsed = time.perf_counter() - started_at
+
+    artifact, manifest_path, checksum_path = (
+        GraphArtifactRepository.companion_paths(args.output)
+    )
+    logger.info(
+        "Graph artifact 빌드 완료: nodes=%s, edges=%s, size=%.1f MiB, elapsed=%.1fs",
+        manifest["node_count"],
+        manifest["edge_count"],
+        manifest["artifact_size_bytes"] / 1024 / 1024,
+        elapsed,
+    )
+    logger.info("artifact: %s", artifact.resolve())
+    logger.info("manifest: %s", manifest_path.resolve())
+    logger.info("checksum: %s", checksum_path.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,4 +1,6 @@
 import os
+from typing import Literal
+
 from pydantic_settings import BaseSettings
 
 
@@ -9,6 +11,12 @@ class Settings(BaseSettings):
     POSTGRES_DB: str = "seoul_walk"
     POSTGRES_HOST: str = "localhost"
     POSTGRES_PORT: int = 5434
+
+    # Walk Graph
+    WALK_GRAPH_SOURCE: Literal["database", "artifact"] = "database"
+    WALK_GRAPH_ARTIFACT_PATH: str = "artifacts/walk_graph_v1.pkl"
+    WALK_GRAPH_DATA_VERSION: str = "v1-2026-07-30"
+    WALK_GRAPH_EXPECTED_COMMIT: str = ""
 
     # Valkey
     VALKEY_URI: str = "redis://localhost:6379"

--- a/src/interfaces/dependencies.py
+++ b/src/interfaces/dependencies.py
@@ -1,5 +1,7 @@
+import logging
 from typing import Optional
 
+from src.config.settings import settings
 from src.service import (
     KakaoLoginService,
     UserService,
@@ -21,7 +23,12 @@ from src.infrastructure.external.client import (
     MarathonClient,
     WeatherClient
 )
+from src.repository.network.graph_artifact_repository import (
+    GraphArtifactRepository,
+)
 from src.repository.network.graph_repository import GraphRepository
+
+logger = logging.getLogger(__name__)
 
 # 싱글톤 패턴
 auth_service        = AuthService()
@@ -38,9 +45,24 @@ route_service: Optional[RouteService] = None
 prewalk_orchestrator: Optional[PrewalkOrchestrator] = None
 
 # lifespan에서 호출
+def load_runtime_graph():
+    if settings.WALK_GRAPH_SOURCE == "artifact":
+        logger.info(
+            "배포용 Graph artifact를 로드합니다: %s",
+            settings.WALK_GRAPH_ARTIFACT_PATH,
+        )
+        return GraphArtifactRepository.load(
+            settings.WALK_GRAPH_ARTIFACT_PATH,
+            expected_data_version=settings.WALK_GRAPH_DATA_VERSION,
+            expected_source_commit=settings.WALK_GRAPH_EXPECTED_COMMIT or None,
+        )
+    logger.info("PostgreSQL에서 도보 Graph를 생성합니다.")
+    return GraphRepository.load_graph()
+
+
 def init_route_service():
     global G, route_service, prewalk_orchestrator
-    G             = GraphRepository.load_graph()
+    G             = load_runtime_graph()
     route_service = RouteService(G=G, auth_service=auth_service)
     prewalk_orchestrator = PrewalkOrchestrator(
         weather_checker = WeatherChecker(weather_client=weather_client),

--- a/src/repository/network/graph_artifact_repository.py
+++ b/src/repository/network/graph_artifact_repository.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pickle
+import platform
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+
+
+class GraphArtifactError(RuntimeError):
+    """배포용 Graph artifact가 없거나 계약과 다를 때 발생합니다."""
+
+
+class GraphArtifactRepository:
+    SCHEMA_VERSION = 1
+    REQUIRED_NODE_ATTRIBUTES = frozenset(
+        {
+            "lon",
+            "lat",
+            "node_type",
+            "is_underground",
+            "is_overpass",
+        }
+    )
+    REQUIRED_EDGE_ATTRIBUTES = frozenset(
+        {
+            "link_id",
+            "length",
+            "raw_link_type_code",
+            "is_walkable",
+            "safety_score",
+            "nature_score",
+            "slope_score",
+            "running_score",
+            "landmark_score",
+            "child_score",
+            "park_overlap_ratio",
+            "convenience_score",
+            "is_school_zone",
+            "is_vehicle_caution",
+            "toilet_count",
+            "transit_count",
+            "accessibility_poi_count",
+            "tags",
+        }
+    )
+
+    @staticmethod
+    def companion_paths(artifact_path: str | Path) -> tuple[Path, Path, Path]:
+        artifact = Path(artifact_path)
+        if artifact.suffix != ".pkl":
+            raise GraphArtifactError("Graph artifact 확장자는 .pkl이어야 합니다.")
+        base_name = artifact.name.removesuffix(".pkl")
+        return (
+            artifact,
+            artifact.with_name(f"{base_name}.manifest.json"),
+            artifact.with_name(f"{base_name}.sha256"),
+        )
+
+    @staticmethod
+    def _sha256(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    @classmethod
+    def _validate_graph(cls, graph: nx.Graph) -> None:
+        if not isinstance(graph, nx.Graph) or graph.is_directed() or graph.is_multigraph():
+            raise GraphArtifactError("artifact는 무방향 단순 NetworkX Graph여야 합니다.")
+        if graph.number_of_nodes() == 0 or graph.number_of_edges() == 0:
+            raise GraphArtifactError("빈 Graph는 배포 artifact로 저장할 수 없습니다.")
+
+        for node_id, attributes in graph.nodes(data=True):
+            missing = cls.REQUIRED_NODE_ATTRIBUTES.difference(attributes)
+            if missing:
+                raise GraphArtifactError(
+                    f"노드 {node_id}의 필수 속성이 없습니다: {sorted(missing)}"
+                )
+
+        for start, end, attributes in graph.edges(data=True):
+            missing = cls.REQUIRED_EDGE_ATTRIBUTES.difference(attributes)
+            if missing:
+                raise GraphArtifactError(
+                    f"엣지 ({start}, {end})의 필수 속성이 없습니다: {sorted(missing)}"
+                )
+
+    @staticmethod
+    def _runtime_version_matches(built: str, current: str) -> bool:
+        return built.split(".")[:2] == current.split(".")[:2]
+
+    @classmethod
+    def save(
+        cls,
+        graph: nx.Graph,
+        artifact_path: str | Path,
+        *,
+        data_version: str,
+        source_commit: str,
+        source_dirty: bool,
+    ) -> dict[str, Any]:
+        cls._validate_graph(graph)
+        artifact, manifest_path, checksum_path = cls.companion_paths(artifact_path)
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+
+        artifact_tmp = artifact.with_name(f".{artifact.name}.tmp")
+        manifest_tmp = manifest_path.with_name(f".{manifest_path.name}.tmp")
+        checksum_tmp = checksum_path.with_name(f".{checksum_path.name}.tmp")
+
+        try:
+            with artifact_tmp.open("wb") as file:
+                pickle.dump(graph, file, protocol=pickle.HIGHEST_PROTOCOL)
+            os.replace(artifact_tmp, artifact)
+
+            artifact_sha256 = cls._sha256(artifact)
+            manifest = {
+                "artifact_schema_version": cls.SCHEMA_VERSION,
+                "artifact_file": artifact.name,
+                "artifact_sha256": artifact_sha256,
+                "artifact_size_bytes": artifact.stat().st_size,
+                "created_at_utc": datetime.now(timezone.utc).isoformat(),
+                "data_version": data_version,
+                "source_commit": source_commit,
+                "source_dirty": source_dirty,
+                "python_version": platform.python_version(),
+                "networkx_version": nx.__version__,
+                "graph_type": type(graph).__name__,
+                "node_count": graph.number_of_nodes(),
+                "edge_count": graph.number_of_edges(),
+            }
+
+            manifest_tmp.write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            os.replace(manifest_tmp, manifest_path)
+
+            checksum_tmp.write_text(
+                f"{artifact_sha256}  {artifact.name}\n",
+                encoding="utf-8",
+            )
+            os.replace(checksum_tmp, checksum_path)
+            return manifest
+        finally:
+            for temporary in (artifact_tmp, manifest_tmp, checksum_tmp):
+                temporary.unlink(missing_ok=True)
+
+    @classmethod
+    def load(
+        cls,
+        artifact_path: str | Path,
+        *,
+        allow_dirty: bool = False,
+        expected_data_version: str | None = None,
+        expected_source_commit: str | None = None,
+    ) -> nx.Graph:
+        artifact, manifest_path, checksum_path = cls.companion_paths(artifact_path)
+        for path in (artifact, manifest_path, checksum_path):
+            if not path.is_file():
+                raise GraphArtifactError(f"Graph artifact 구성 파일이 없습니다: {path}")
+
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise GraphArtifactError(f"manifest를 읽을 수 없습니다: {exc}") from exc
+
+        if manifest.get("artifact_schema_version") != cls.SCHEMA_VERSION:
+            raise GraphArtifactError(
+                "지원하지 않는 Graph artifact schema입니다: "
+                f"{manifest.get('artifact_schema_version')}"
+            )
+        if manifest.get("source_dirty") and not allow_dirty:
+            raise GraphArtifactError("미커밋 코드에서 생성된 artifact는 배포할 수 없습니다.")
+        if (
+            expected_data_version
+            and manifest.get("data_version") != expected_data_version
+        ):
+            raise GraphArtifactError(
+                "Graph 데이터 버전이 다릅니다: "
+                f"expected={expected_data_version}, "
+                f"actual={manifest.get('data_version')}"
+            )
+        if (
+            expected_source_commit
+            and manifest.get("source_commit") != expected_source_commit
+        ):
+            raise GraphArtifactError(
+                "Graph 생성 커밋이 다릅니다: "
+                f"expected={expected_source_commit}, "
+                f"actual={manifest.get('source_commit')}"
+            )
+        if not cls._runtime_version_matches(
+            str(manifest.get("python_version", "")),
+            platform.python_version(),
+        ):
+            raise GraphArtifactError("artifact와 실행 환경의 Python major/minor가 다릅니다.")
+        if not cls._runtime_version_matches(
+            str(manifest.get("networkx_version", "")),
+            nx.__version__,
+        ):
+            raise GraphArtifactError("artifact와 실행 환경의 NetworkX major/minor가 다릅니다.")
+
+        artifact_sha256 = cls._sha256(artifact)
+        checksum_parts = checksum_path.read_text(encoding="utf-8").split()
+        if not checksum_parts:
+            raise GraphArtifactError("checksum 파일이 비어 있습니다.")
+        checksum_sha256 = checksum_parts[0]
+        if artifact_sha256 != manifest.get("artifact_sha256"):
+            raise GraphArtifactError("artifact SHA-256이 manifest와 다릅니다.")
+        if artifact_sha256 != checksum_sha256:
+            raise GraphArtifactError("artifact SHA-256이 checksum 파일과 다릅니다.")
+
+        try:
+            with artifact.open("rb") as file:
+                graph = pickle.load(file)
+        except (OSError, pickle.PickleError, EOFError) as exc:
+            raise GraphArtifactError(f"Graph artifact를 읽을 수 없습니다: {exc}") from exc
+
+        cls._validate_graph(graph)
+        if graph.number_of_nodes() != manifest.get("node_count"):
+            raise GraphArtifactError("Graph 노드 수가 manifest와 다릅니다.")
+        if graph.number_of_edges() != manifest.get("edge_count"):
+            raise GraphArtifactError("Graph 엣지 수가 manifest와 다릅니다.")
+        return graph

--- a/tests/unit/test_graph_artifact_repository.py
+++ b/tests/unit/test_graph_artifact_repository.py
@@ -1,0 +1,135 @@
+import json
+
+import networkx as nx
+import pytest
+
+from src.repository.network.graph_artifact_repository import (
+    GraphArtifactError,
+    GraphArtifactRepository,
+)
+
+
+def make_graph() -> nx.Graph:
+    graph = nx.Graph()
+    node_attributes = {
+        "node_type": "walk",
+        "is_underground": False,
+        "is_overpass": False,
+    }
+    graph.add_node(1, lon=126.9, lat=37.5, **node_attributes)
+    graph.add_node(2, lon=126.91, lat=37.51, **node_attributes)
+    graph.add_edge(
+        1,
+        2,
+        link_id=10,
+        length=100.0,
+        raw_link_type_code="1010",
+        is_walkable=True,
+        safety_score=0.5,
+        nature_score=0.4,
+        slope_score=1.0,
+        running_score=0.2,
+        landmark_score=0.0,
+        child_score=0.0,
+        park_overlap_ratio=0.3,
+        convenience_score=0.5,
+        is_school_zone=False,
+        is_vehicle_caution=False,
+        toilet_count=1,
+        transit_count=2,
+        accessibility_poi_count=0,
+        tags=[],
+    )
+    return graph
+
+
+def save_graph(tmp_path, graph=None):
+    artifact_path = tmp_path / "walk_graph_v1.pkl"
+    manifest = GraphArtifactRepository.save(
+        graph or make_graph(),
+        artifact_path,
+        data_version="test-v1",
+        source_commit="abc123",
+        source_dirty=False,
+    )
+    return artifact_path, manifest
+
+
+def test_save_and_load_round_trip(tmp_path):
+    artifact_path, manifest = save_graph(tmp_path)
+
+    loaded = GraphArtifactRepository.load(artifact_path)
+
+    assert loaded.number_of_nodes() == 2
+    assert loaded.number_of_edges() == 1
+    assert loaded[1][2]["park_overlap_ratio"] == 0.3
+    assert manifest["data_version"] == "test-v1"
+    assert manifest["source_commit"] == "abc123"
+    assert manifest["source_dirty"] is False
+
+
+def test_save_creates_manifest_and_checksum(tmp_path):
+    artifact_path, manifest = save_graph(tmp_path)
+    _, manifest_path, checksum_path = GraphArtifactRepository.companion_paths(
+        artifact_path
+    )
+
+    saved_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    checksum = checksum_path.read_text(encoding="utf-8").split()[0]
+
+    assert saved_manifest == manifest
+    assert checksum == manifest["artifact_sha256"]
+    assert manifest["artifact_size_bytes"] == artifact_path.stat().st_size
+
+
+def test_load_rejects_tampered_artifact(tmp_path):
+    artifact_path, _ = save_graph(tmp_path)
+    with artifact_path.open("ab") as file:
+        file.write(b"tampered")
+
+    with pytest.raises(GraphArtifactError, match="manifest"):
+        GraphArtifactRepository.load(artifact_path)
+
+
+def test_load_rejects_dirty_source_manifest(tmp_path):
+    artifact_path, _ = save_graph(tmp_path)
+    _, manifest_path, _ = GraphArtifactRepository.companion_paths(artifact_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["source_dirty"] = True
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(GraphArtifactError, match="미커밋"):
+        GraphArtifactRepository.load(artifact_path)
+
+
+def test_load_rejects_unexpected_data_version(tmp_path):
+    artifact_path, _ = save_graph(tmp_path)
+
+    with pytest.raises(GraphArtifactError, match="데이터 버전"):
+        GraphArtifactRepository.load(
+            artifact_path,
+            expected_data_version="different-version",
+        )
+
+
+def test_load_rejects_unexpected_source_commit(tmp_path):
+    artifact_path, _ = save_graph(tmp_path)
+
+    with pytest.raises(GraphArtifactError, match="생성 커밋"):
+        GraphArtifactRepository.load(
+            artifact_path,
+            expected_source_commit="different-commit",
+        )
+
+
+def test_save_rejects_missing_required_attributes(tmp_path):
+    graph = make_graph()
+    del graph[1][2]["safety_score"]
+
+    with pytest.raises(GraphArtifactError, match="필수 속성"):
+        save_graph(tmp_path, graph)
+
+
+def test_companion_paths_require_pickle_extension(tmp_path):
+    with pytest.raises(GraphArtifactError, match=".pkl"):
+        GraphArtifactRepository.companion_paths(tmp_path / "walk_graph.json")

--- a/tests/unit/test_runtime_graph_loading.py
+++ b/tests/unit/test_runtime_graph_loading.py
@@ -1,0 +1,47 @@
+from src.interfaces import dependencies
+
+
+def test_runtime_graph_uses_database_by_default(monkeypatch):
+    expected = object()
+    monkeypatch.setattr(dependencies.settings, "WALK_GRAPH_SOURCE", "database")
+    monkeypatch.setattr(
+        dependencies.GraphRepository,
+        "load_graph",
+        lambda: expected,
+    )
+
+    assert dependencies.load_runtime_graph() is expected
+
+
+def test_runtime_graph_uses_artifact_in_deployment_mode(monkeypatch):
+    expected = object()
+    monkeypatch.setattr(dependencies.settings, "WALK_GRAPH_SOURCE", "artifact")
+    monkeypatch.setattr(
+        dependencies.settings,
+        "WALK_GRAPH_ARTIFACT_PATH",
+        "artifacts/test.pkl",
+    )
+    monkeypatch.setattr(
+        dependencies.settings,
+        "WALK_GRAPH_DATA_VERSION",
+        "test-v1",
+    )
+    monkeypatch.setattr(
+        dependencies.settings,
+        "WALK_GRAPH_EXPECTED_COMMIT",
+        "abc123",
+    )
+    monkeypatch.setattr(
+        dependencies.GraphArtifactRepository,
+        "load",
+        lambda path, **kwargs: (expected, path, kwargs),
+    )
+
+    graph, path, options = dependencies.load_runtime_graph()
+
+    assert graph is expected
+    assert path == "artifacts/test.pkl"
+    assert options == {
+        "expected_data_version": "test-v1",
+        "expected_source_commit": "abc123",
+    }


### PR DESCRIPTION
## ☝️Issue Number
- related to #306

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- Cloud Run 시작 시 전체 도보망을 DB에서 매번 생성하지 않도록 배포용 NetworkX Graph 빌더를 추가했습니다.
- 빌드된 Graph 파일을 검증하고 로드하는 배포용 경로를 구현했습니다.
- 개발 환경에서는 기존 DB 로드 방식을 유지하고, 배포 환경에서는 artifact를 선택하도록 분리했습니다.

## 📦 빌드 결과
- 노드: 160,188개
- 엣지: 223,664개
- Graph 파일: 약 64.1MB
- 전달용 ZIP: 약 8.6MB
- artifact 검증·로드: 약 2.4초
- 기준 커밋: `55d30b0`
- `source_dirty=false` 확인

## 🔍 검증 항목
- Graph 데이터 버전
- 생성 Git 커밋
- Python·NetworkX 버전
- 노드·엣지 수
- SHA-256 checksum
- 미커밋 코드에서 생성된 artifact 차단
- 변조되거나 구성 파일이 누락된 artifact 차단

## ✅ 테스트
- 관련 테스트 `101 passed`
- Ruff 검사 통과
- Graph 저장 후 strict 재로드 성공
- manifest와 checksum 일치 확인

## 📁 배포팀 인계
- Graph artifact와 ZIP은 Git에 포함하지 않고 별도로 전달합니다.
- 배포 환경에서는 다음 값을 설정해야 합니다.

```text
WALK_GRAPH_SOURCE=artifact
WALK_GRAPH_ARTIFACT_PATH=artifacts/walk_graph_v1.pkl
WALK_GRAPH_DATA_VERSION=v1-2026-07-30
```

## ⚠️ 남은 작업
- 현재 루트 Dockerfile은 PostGIS용이므로 FastAPI용 Dockerfile 분리가 필요합니다.
- 실제 컨테이너 메모리와 Cloud Run cold start는 배포 단계에서 확인해야 합니다.