### PR TITLE
feat: A* 휴리스틱을 랜드마크 기반(ALT)으로 교체

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -55,6 +55,7 @@ from benchmarks.solvers.plateau_solver import PlateauSolver
 from benchmarks.solvers.rcsp_solver import CircularRcspSolver, OnewayRcspSolver
 from benchmarks.solvers.astar_solver import OnewayAstarSolver
 from benchmarks.solvers.dijkstra_solver import OnewayDijkstraSolver
+from src.route_engine.engines.oneway_astar import precompute_landmarks
 
 logger = logging.getLogger(__name__)
 
@@ -441,6 +442,10 @@ def main():
         params["time_budget_sec"] = args.time_budget
 
     solvers = resolve_solvers(args.algo)
+
+    if graph is not None and any(isinstance(s, OnewayAstarSolver) for s in solvers):
+        logger.info("랜드마크 전처리 중...")
+        precompute_landmarks(graph)
 
     result_df = run_benchmark(solvers, graph, start_node, target_node, params, timeout_sec=args.timeout)
 

--- a/benchmarks/run_all_scenarios.py
+++ b/benchmarks/run_all_scenarios.py
@@ -8,10 +8,13 @@ import pandas as pd
 from benchmarks.config import ROUTE_ENGINE_DATASET
 from benchmarks.benchmark import _load_default_graph, run_benchmark, SOLVER_REGISTRY
 from src.route_engine.engines.path_utils import PathUtils
+from src.route_engine.engines.oneway_astar import precompute_landmarks
 
-ONEWAY_ALGOS   = ["beam-oneway", "grasp-oneway", "alns-oneway", "rcsp-oneway", "plateau", "astar-oneway", "dijkstra-oneway"]
-CIRCULAR_ALGOS = ["beam-circular", "grasp-circular", "alns-circular", "rcsp-circular"]
+# ONEWAY_ALGOS   = ["beam-oneway", "grasp-oneway", "alns-oneway", "rcsp-oneway", "plateau", "astar-oneway", "dijkstra-oneway"]
+# CIRCULAR_ALGOS = ["beam-circular", "grasp-circular", "alns-circular", "rcsp-circular"]
 
+ONEWAY_ALGOS   = ["astar-oneway", "dijkstra-oneway"]
+CIRCULAR_ALGOS = []
 
 def main():
     print("그래프 로딩 중...", flush=True)
@@ -19,6 +22,10 @@ def main():
     graph = _load_default_graph()
     print(f"그래프 로딩 완료: {time.perf_counter() - t0:.1f}초, 노드 {graph.number_of_nodes()}개, 엣지 {graph.number_of_edges()}개", flush=True)
 
+    print("랜드마크 전처리 중...", flush=True)
+    t_lm = time.perf_counter()
+    precompute_landmarks(graph)
+    print(f"랜드마크 전처리 완료: {time.perf_counter() - t_lm:.1f}초", flush=True)
     utils = PathUtils(graph)
 
     with open(ROUTE_ENGINE_DATASET, encoding="utf-8") as f:

--- a/benchmarks/solvers/astar_solver.py
+++ b/benchmarks/solvers/astar_solver.py
@@ -3,6 +3,7 @@ from benchmarks.solvers.base_solver import BasePathSolver
 from src.route_engine.engines.oneway_astar import OnewayAstarEngine
 from src.route_engine.scoring.scoring_engine import calculate_custom_score
 from src.schema.route_schema import OnewayRouteInput
+import time
 
 _DEFAULT_TARGET_KM = 3.0
 
@@ -17,20 +18,26 @@ class OnewayAstarSolver(BasePathSolver):
             start_lat=0.0, start_lon=0.0, end_lat=0.0, end_lon=0.0, target_km=target_km,
         )
 
+        t0 = time.perf_counter()
         engine = OnewayAstarEngine(
             inp=inp,
             G=graph,
             custom_weights=params.get("custom_weights"),
             profile=params.get("profile"),
         )
+        t1 = time.perf_counter()
         calculate_custom_score(engine.G, {
             "mode": engine.scoring_mode,
             "weights": engine.weights,
             "blocked_tags": engine.blocked_tags,
         })
         engine._min_ratio = engine._min_cost_per_m()
+        t2 = time.perf_counter()
 
         nodes = engine.find_path(start_node, target_node)
+        t3 = time.perf_counter()
+        print(f"[A* 진단] G.copy={t1-t0:.3f}s, custom_score+min_ratio={t2-t1:.3f}s, find_path={t3-t2:.3f}s")
+
         if not nodes or len(nodes) < 2:
             raise ValueError("경로 생성 실패: 유효한 편도 경로를 찾지 못했습니다 (NO_PATH)")
 

--- a/src/route_engine/engines/oneway_astar.py
+++ b/src/route_engine/engines/oneway_astar.py
@@ -13,6 +13,7 @@ from src.schema.route_schema import OnewayRouteInput, Weights
 from src.route_engine.scoring.scoring_engine import calculate_custom_score
 
 logger = logging.getLogger(__name__)
+_NUM_LANDMARKS = 8  # 그래프 경계 8방향(동서남북+대각선) 기준
 
 class OnewayAstarEngine:
     def __init__(
@@ -101,11 +102,12 @@ class OnewayAstarEngine:
         A* 알고리즘으로 최단 경로 노드 목록을 반환합니다.
         """
         try:
-            return nx.astar_path(
+            path = nx.astar_path(
                 self.G, start, end,
                 heuristic=self._heuristic,
                 weight="custom_score",
             )
+            return path
         except nx.NetworkXNoPath:
             logger.warning("출발-도착 노드 사이에 연결된 경로가 없습니다")
             return []
@@ -125,10 +127,39 @@ class OnewayAstarEngine:
 
     def _heuristic(self, node: int, target: int) -> float:
         """
-        A* 휴리스틱: 직선거리(m) × 그래프 최소 비용/거리 비율.
-        landmark/child 보너스로 custom_score < length가 되는 프로필에서도 과대평가하지 않음.
+        A* 휴리스틱: 랜드마크 삼각부등식 기반 도로망거리 추정 × 최소 비용/거리 비율.
         """
-        d = self.G.nodes[node]
-        t = self.G.nodes[target]
-        dist_m = self.utils._haversine_m(d.get("lat", 0), d.get("lon", 0), t.get("lat", 0), t.get("lon", 0))
-        return dist_m * self._min_ratio
+        self._heuristic_calls = getattr(self, "_heuristic_calls", 0) + 1
+        d_node   = self.G.nodes[node]["landmark_dist"]
+        d_target = self.G.nodes[target]["landmark_dist"]
+        network_est = max(abs(a - b) for a, b in zip(d_node, d_target))
+        return network_est * self._min_ratio
+    
+def precompute_landmarks(G: nx.Graph) -> None:
+    """
+    그래프 경계 근처 8개 노드를 랜드마크로 선정하고, 각 랜드마크에서 전체 노드까지의
+    실제 도로망 거리(m, length 기준 — 프로필 무관)를 미리 계산해 노드 속성에 저장합니다.
+    A* 휴리스틱에서 삼각부등식 기반 하한(ALT)으로 사용합니다.
+    그래프 로드 시 한 번만 호출하면 되고, 프로필이 달라져도 재계산할 필요 없습니다.
+    """
+    landmarks = _select_landmarks(G)
+    for lm in landmarks:
+        dist = nx.single_source_dijkstra_path_length(G, lm, weight="length")
+        for node in G.nodes:
+            G.nodes[node].setdefault("landmark_dist", []).append(dist.get(node, float("inf")))
+    G.graph["landmark_nodes"] = landmarks
+
+
+def _select_landmarks(G: nx.Graph) -> list[int]:
+    """
+    위도/경도 극값(동서남북 + 대각선 4방향) 근처 노드를 랜드마크로 선정합니다.
+    """
+    nodes = list(G.nodes(data=True))
+    by_lat = sorted(nodes, key=lambda nd: nd[1].get("lat", 0))
+    by_lon = sorted(nodes, key=lambda nd: nd[1].get("lon", 0))
+    candidates = {by_lat[0][0], by_lat[-1][0], by_lon[0][0], by_lon[-1][0]}
+    candidates.add(min(nodes, key=lambda nd: nd[1].get("lat", 0) + nd[1].get("lon", 0))[0])
+    candidates.add(max(nodes, key=lambda nd: nd[1].get("lat", 0) + nd[1].get("lon", 0))[0])
+    candidates.add(max(nodes, key=lambda nd: nd[1].get("lat", 0) - nd[1].get("lon", 0))[0])
+    candidates.add(min(nodes, key=lambda nd: nd[1].get("lat", 0) - nd[1].get("lon", 0))[0])
+    return list(candidates)

--- a/src/route_engine/engines/oneway_rcsp.py
+++ b/src/route_engine/engines/oneway_rcsp.py
@@ -190,7 +190,6 @@ class OnewayRcspEngine:
 
         for step in range(_MAX_STEPS):
             if not frontier:
-                logger.warning("[RCSP 진단] step=%d에서 frontier 고갈로 중단", step)
                 break
 
             if step % 20 == 0:
@@ -226,11 +225,6 @@ class OnewayRcspEngine:
 
             frontier = self._prune_labels(candidates, end, min_ratio)  # 파레토 + 상한 가지치기
 
-        logger.warning(
-            "[RCSP 진단] 조기도착(소실)=%d건, 정상도착=%d건, 최종 arrived=%d개",
-            early_arrivals, proper_arrivals, len(arrived),
-        )
-        logger.warning("[RCSP 진단] step별 (프론티어 크기, end까지 최소 추정거리m): %s", progress_log)
         return arrived
 
 


### PR DESCRIPTION
## ☝️Issue Number
- resolve #326 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- oneway_astar.py: haversine 직선거리 대신 랜드마크 8곳까지의
  실제 도로망거리(삼각부등식)로 admissible heuristic을 계산하도록 변경
- benchmark.py/run_all_scenarios.py: A* solver 실행 전
  랜드마크 전처리(precompute_landmarks) 단계 연동
- astar_solver.py: 단계별 소요시간 진단 로그 추가
- oneway_rcsp.py: 임시 진단 로그(조기도착/정상도착 카운터) 제거 마무리