### PR TITLE
deploy: 토큰 만료 시간을 환경변수로 조절 가능하도록 변경

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -55,6 +55,7 @@ from benchmarks.solvers.plateau_solver import PlateauSolver
 from benchmarks.solvers.rcsp_solver import CircularRcspSolver, OnewayRcspSolver
 from benchmarks.solvers.astar_solver import OnewayAstarSolver
 from benchmarks.solvers.dijkstra_solver import OnewayDijkstraSolver
+from src.route_engine.engines.oneway_astar import precompute_landmarks
 
 logger = logging.getLogger(__name__)
 
@@ -441,6 +442,10 @@ def main():
         params["time_budget_sec"] = args.time_budget
 
     solvers = resolve_solvers(args.algo)
+
+    if graph is not None and any(isinstance(s, OnewayAstarSolver) for s in solvers):
+        logger.info("랜드마크 전처리 중...")
+        precompute_landmarks(graph)
 
     result_df = run_benchmark(solvers, graph, start_node, target_node, params, timeout_sec=args.timeout)
 

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -6,8 +6,12 @@ BasePathSolver를 상속받은 알고리즘(Strategy)들을 SOLVER_REGISTRY에 �
 CLI에서 --algo로 원하는 것만 골라 실행한다 (전체를 매번 순차 실행하지 않음).
 동일한 입력(graph, start_node, target_node, params)으로 실행하고, 결과를 표로 출력 및
 CSV로 저장한다. 이 프로젝트의 실제 목적("적당한 시간 내에 사용자가 원하는 순환 경로가
-나오는가")에 맞춰, solver의 자기 신고(cost/overlap_ratio)를 그대로 믿지 않고 하네스가
-paths/graph에서 독립적으로 재계산한 품질 지표를 함께 기록한다:
+나오는가")에 맞춰, solver의 자기 신고(cost)를 그대로 믿지 않고 하네스가 paths/graph에서
+독립적으로 재계산한 품질 지표를 함께 기록한다. 단 overlap_ratio는 예외로, solver가
+공용 헬퍼(_oneway_engine_common.base_shortest_path_overlap_ratio)로 직접 계산해
+보고한 값을 그대로 신뢰한다 
+
+모든 oneway solver가 같은 헬퍼를 쓰므로 solver 간 비교 일관성은 유지됨:
 
   - within_time_budget : params['time_budget_sec'](사용자 체감 허용시간) 이내에 끝났는지.
                           timeout_sec(하드 킬 기준)과는 별개로, "기술적으로는 성공했지만
@@ -49,6 +53,8 @@ from benchmarks.solvers.dummy_solver import DummySolver
 from benchmarks.solvers.grasp_solver import CircularGraspSolver, OnewayGraspSolver
 from benchmarks.solvers.plateau_solver import PlateauSolver
 from benchmarks.solvers.rcsp_solver import CircularRcspSolver, OnewayRcspSolver
+from benchmarks.solvers.astar_solver import OnewayAstarSolver
+from benchmarks.solvers.dijkstra_solver import OnewayDijkstraSolver
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +81,8 @@ SOLVER_REGISTRY: dict[str, BasePathSolver] = {
     "rcsp-circular": CircularRcspSolver(),
     "rcsp-oneway": OnewayRcspSolver(),
     "plateau": PlateauSolver(),
+    "astar-oneway": OnewayAstarSolver(),
+    "dijkstra-oneway" : OnewayDijkstraSolver(),
     "dummy-a": DummySolver(name="DummySolver-A", fake_delay_sec=0.05),
     "dummy-b": DummySolver(name="DummySolver-B", fake_delay_sec=0.1),
 }

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -44,6 +44,8 @@ class Settings(BaseSettings):
     # JWT
     ACCESS_SECRET_KEY: str = ""
     REFRESH_SECRET_KEY: str = ""
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 14
 
     # LangSmith
     LANGCHAIN_TRACING_V2: str = "false"

--- a/src/service/user/auth_service.py
+++ b/src/service/user/auth_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 from jwt.exceptions import ExpiredSignatureError, InvalidSignatureError, DecodeError, InvalidTokenError
 
+from src.config.settings import settings
 from src.repository.user.user_repository import UserRepository
 from src.infrastructure.cache.repository.user_repository import UserRepository as CacheUserRepository
 from src.interfaces.schema.auth_schema import Status
@@ -25,7 +26,7 @@ class AuthService:
         access_payload = {
             "provider": provider.value,
             "provider_id": provider_id,
-            "exp": now + timedelta(minutes=60),
+            "exp": now + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
             "type": "access"
         }
         access_token = jwt.encode(access_payload, self.ACCESS_SECRET_KEY, algorithm="HS256")
@@ -41,7 +42,7 @@ class AuthService:
         refresh_payload = {
             "provider": provider.value,
             "provider_id": provider_id,
-            "exp": now + timedelta(days=14),
+            "exp": now + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
             "type": "refresh"
         }
         refresh_token = jwt.encode(refresh_payload, self.REFRESH_SECRET_KEY, algorithm="HS256")


### PR DESCRIPTION
## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- ACCESS_TOKEN_EXPIRE_MINUTES (기본값 60)
- REFRESH_TOKEN_EXPIRE_DAYS (기본값 14)
- 기본값이 있어 .env 수정 없이 기존 동작 유지
- 프론트 팀의 토큰 만료 동작 테스트를 위해 추가
