### PR TITLE
docs: 백엔드 배포 문서 추가 및 인증 문서 갱신

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 | 담당 업무 | 시작 문서 |
 |---|---|
 | 인증·Kakao 로그인 | [authentication/README.md](authentication/README.md) |
+| Cloud Run 배포 | [deployment/README.md](deployment/README.md) |
 | 챗봇 | [chatbot/README.md](chatbot/README.md) |
 | 데이터 | [data/README.md](data/README.md) |
 | 경로 엔진·Graph | [route_engine/README.md](route_engine/README.md) |
@@ -58,6 +59,8 @@ docs/                              // 프로젝트 문서
 │   ├── data_ingestion.md          // 데이터 적재 절차
 │   ├── data_rebuild.md            // V1 전체 재구축·검증·복구
 │   └── testing.md                 // 테스트 작성 구조
+├── deployment/                    // Cloud Run 배포 영역
+│   └── README.md                  // Docker·cloudbuild·시크릿·마이그레이션 계약
 ├── proposals/                     // 아직 구현하지 않은 변경 제안
 │   ├── chatbot_upgrade_proposal.md // 챗봇 업그레이드 결정·작업 단위
 │   ├── chatbot_cleanup_proposal.md // 챗봇 불필요한 항목 제거 발견 목록
@@ -75,6 +78,7 @@ docs/                              // 프로젝트 문서
 도메인 작업:
 
 - [인증·Kakao 로그인](authentication/README.md)
+- [Cloud Run 배포](deployment/README.md)
 - [데이터](data/README.md)
 - [챗봇](chatbot/README.md)
 - [챗봇 Agent 하네스](chatbot/agent_harness.md)

--- a/docs/authentication/README.md
+++ b/docs/authentication/README.md
@@ -1,7 +1,7 @@
 # 인증·Kakao 로그인 계약
 
 > 상태: Current  
-> 기준일: 2026-07-27  
+> 기준일: 2026-08-03  
 > 관련 코드: `src/interfaces/api/auth_router.py`, `src/interfaces/api/login_router.py`, `src/service/user/auth_service.py`, `src/service/user/login_service.py`
 
 ## 1. 책임
@@ -32,6 +32,8 @@
 
 - `KAKAO_API_KEY`, `KAKAO_REDIRECT_URI`
 - `ACCESS_SECRET_KEY`, `REFRESH_SECRET_KEY`
+- `ACCESS_TOKEN_EXPIRE_MINUTES` (기본값 60, 단위: 분) — access token 만료 시간 조절
+- `REFRESH_TOKEN_EXPIRE_DAYS` (기본값 14, 단위: 일) — refresh token 만료 시간 조절
 - PostgreSQL 연결
 - Valkey 연결
 
@@ -51,9 +53,9 @@
 저장 결과:
 
 - PostgreSQL `users`: 최초 로그인 사용자 저장
-- Valkey `refresh_token:{provider}:{provider_id}`: refresh JWT, TTL 1,209,600초
-- access JWT 만료: 60분
-- refresh JWT 만료: 14일
+- Valkey `refresh_token:{provider}:{provider_id}`: refresh JWT, TTL은 `REFRESH_TOKEN_EXPIRE_DAYS × 86,400`초 (기본 1,209,600초 = 14일)
+- access JWT 만료: `ACCESS_TOKEN_EXPIRE_MINUTES`분 (기본값 60분)
+- refresh JWT 만료: `REFRESH_TOKEN_EXPIRE_DAYS`일 (기본값 14일)
 
 웹·모바일 `LoginResponse` body에는 현재 access·refresh token이 모두 포함된다.
 
@@ -107,6 +109,8 @@ access·refresh 확인 endpoint는 cookie가 아니라 선택적 Bearer header�
 | 변경 | 함께 확인할 대상 |
 |---|---|
 | JWT payload·secret·algorithm | 모든 `check_access_token` 호출자, 기존 token |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` 변경 | cookie Max-Age(3,600초 하드코딩)와 불일치 발생 가능 — cookie 설정도 함께 수정 필요 |
+| `REFRESH_TOKEN_EXPIRE_DAYS` 변경 | Valkey TTL, cookie Max-Age(1,209,600초 하드코딩)와 불일치 발생 가능 — cookie 설정도 함께 수정 필요 |
 | access·refresh 만료 | cookie Max-Age, Valkey TTL, 복구 안내 |
 | `AuthService` 반환 tuple | user·survey·route·prewalk service와 테스트 mock |
 | token 전달 위치 | auth Bearer header, 로그인 body, 웹 callback·refresh cookie, logout cookie |

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,247 @@
+# Cloud Run 배포 계약
+
+> 상태: Current  
+> 기준일: 2026-08-03  
+> 관련 코드: `Dockerfile.api`, `cloudbuild.yaml`, `requirements.txt`, `src/config/settings.py`, `src/database/postgresql.py`, `src/entity/base.py`, `scripts/gen_test_token.py`, `scripts/check_graph_db_consistency.py`
+
+## 1. 책임
+
+이 영역은 ROUDI 백엔드 API를 Google Cloud Run에 빌드·배포하고, 프로덕션 환경에서 안전하게 실행되도록 구성을 관리한다.
+
+담당:
+- Docker 이미지 빌드 (`Dockerfile.api`)
+- Artifact Registry에 이미지 push
+- Cloud Run 서비스 배포 (`cloudbuild.yaml`)
+- 프로덕션 전용 환경변수·시크릿 관리 (Secret Manager 연동)
+- DB 연결 풀·SSL 설정 (`src/database/postgresql.py`)
+- DB 스키마 자동 마이그레이션 모드 (`src/entity/base.py`)
+- 배포 전후 검증 스크립트 (`scripts/`)
+
+담당하지 않음:
+- 로컬 개발 환경 실행 → [`docs/operations/backend_runtime.md`](../operations/backend_runtime.md)
+- Supabase PostgreSQL 스키마 설계 → 데이터 영역
+- Valkey 데이터 구조 → 인증 영역
+- 인증 JWT 로직 → [`docs/authentication/README.md`](../authentication/README.md)
+
+## 2. 입력
+
+### Cloud Build 실행 시 substitution 변수
+
+| 변수 | 확정값 | 설명 |
+|---|---|---|
+| `_AR_REGION` | `asia-northeast3` | Artifact Registry 리전 |
+| `_AR_REPO` | `seoul-walk` | Artifact Registry 저장소 이름 |
+| `_RUN_REGION` | `asia-northeast3` | Cloud Run 배포 리전 |
+| `_SERVICE` | `seoul-walk-api` | Cloud Run 서비스 이름 |
+| `_TAG` | `latest` (수동 실행 시 커밋 해시 권장) | 이미지 태그 |
+
+### Cloud Run 비민감 환경변수 (cloudbuild.yaml에 하드코딩)
+
+| 변수 | 값 |
+|---|---|
+| `POSTGRES_HOST` | `aws-1-ap-northeast-2.pooler.supabase.com` |
+| `POSTGRES_PORT` | `5432` |
+| `POSTGRES_USER` | `postgres.cbtqbecddiepzrzrcnou` |
+| `POSTGRES_DB` | `postgres` |
+| `POSTGRES_SSL_MODE` | `require` |
+| `DB_POOL_SIZE` | `2` |
+| `DB_MAX_OVERFLOW` | `3` |
+| `WALK_GRAPH_SOURCE` | `artifact` |
+| `WALK_GRAPH_DATA_VERSION` | `v1-2026-07-30` |
+| `WALK_GRAPH_EXPECTED_COMMIT` | `55d30b0cdef16b2bfdd04723fbac39e397bd5f58` |
+| `DB_AUTO_MIGRATE` | `create` |
+| `LANGCHAIN_TRACING_V2` | `false` |
+
+### Secret Manager 시크릿 (프로덕션 실행 전 미리 생성 필요)
+
+| 시크릿 이름 | 주입되는 환경변수 |
+|---|---|
+| `postgres-password` | `POSTGRES_PASSWORD` |
+| `valkey-uri` | `VALKEY_URI` |
+| `openai-api-key` | `OPENAI_API_KEY` |
+| `kakao-api-key` | `KAKAO_API_KEY` |
+| `mapbox-api-key` | `MAPBOX_API_KEY` |
+| `weather-api-key` | `WEATHER_API_KEY` |
+| `air-korea-api-key` | `AIR_KOREA_API_KEY` |
+| `public-data-api-key` | `PUBLIC_DATA_API_KEY` |
+| `access-secret-key` | `ACCESS_SECRET_KEY` |
+| `refresh-secret-key` | `REFRESH_SECRET_KEY` |
+
+### Dockerfile 입력
+
+| 파일·경로 | 역할 |
+|---|---|
+| `requirements.txt` | pip 의존성 (Poetry 없이 빌드) |
+| `artifacts/walk_graph_v1.pkl` | 도보 그래프 artifact (약 64 MB) |
+| `src/` | 애플리케이션 소스 |
+
+## 3. 출력
+
+| 결과 | 위치 |
+|---|---|
+| Docker 이미지 (`sha` 태그) | `asia-northeast3-docker.pkg.dev/{PROJECT_ID}/seoul-walk/seoul-walk-api:{TAG}` |
+| Docker 이미지 (`latest` 태그) | 동일 경로의 `:latest` |
+| Cloud Run 서비스 (배포 완료) | `seoul-walk-api` (asia-northeast3) |
+
+**현재 운영 중인 서비스 URL**: `https://seoul-walk-api-973252334772.asia-northeast3.run.app`
+
+2026-08-03 기준 동작 확인 완료:
+- `/api/health` 헬스체크
+- 경로 생성 API
+- Kakao 로그인
+
+## 4. 실행 진입점
+
+### Cloud Build 파이프라인 (`cloudbuild.yaml`)
+
+```text
+1. build  : docker build -f Dockerfile.api → 이미지 생성
+2. push-sha   : Artifact Registry에 커밋 해시 태그 push
+   push-latest: Artifact Registry에 latest 태그 push  (병렬)
+3. deploy : gcloud run deploy seoul-walk-api
+           → 환경변수 주입 + 시크릿 마운트 + Cloud Run 서비스 갱신
+```
+
+### Dockerfile 실행 흐름 (`Dockerfile.api`)
+
+```text
+FROM python:3.12-slim (linux/amd64 고정)
+→ pip install -r requirements.txt
+→ COPY artifacts/ (walk graph pkl — 별도 레이어로 캐시 분리)
+→ COPY src/
+→ useradd appuser (1000)
+→ CMD: uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 1
+```
+
+**주의**: `fiona`는 `libexpat.so.1` 부재로 직접 import 불가하지만 API 런타임 경로에서 호출되지 않아 무관하다. apt 패키지 추가 없이 빌드된다.
+
+### 서버 시작 시 DB 마이그레이션 (`src/entity/base.py`)
+
+`DB_AUTO_MIGRATE` 값에 따라 startup 시 스키마를 자동 동기화한다.
+
+| 모드 | 동작 |
+|---|---|
+| `full` (로컬 기본값) | CREATE TABLE + ADD COLUMN + DROP COLUMN |
+| `create` (프로덕션 기본값) | CREATE TABLE + ADD COLUMN만 허용, DROP 차단 |
+| `off` | 스키마 변경 없음 |
+
+프로덕션에서는 `create`를 사용한다. 컬럼을 실제로 제거해야 할 때는 `off`로 전환 후 수동 마이그레이션한다.
+
+## 5. 의존하는 영역
+
+| 의존 대상 | 역할 |
+|---|---|
+| Supabase PostgreSQL (Session Pooler) | 프로덕션 DB. `sslmode=require`, 포트 5432 |
+| Valkey (Upstash 또는 동급) | refresh token 저장소. `VALKEY_URI` 시크릿으로 주입 |
+| `artifacts/walk_graph_v1.pkl` | 도보 그래프. `WALK_GRAPH_SOURCE=artifact`일 때 사용 |
+| Google Artifact Registry | 빌드 이미지 저장소 |
+| Google Secret Manager | 민감 환경변수 런타임 주입 |
+| Google Cloud Build | CI/CD 파이프라인 실행 |
+
+**DB 풀 설계 근거 (Supabase 대시보드 확인값 기준)**:
+
+Supabase Session Pooler에는 방향이 다른 두 가지 커넥션 한도가 있다.
+
+| 한도 | 값 | 방향 | 의미 |
+|---|---|---|---|
+| Connection pool size | 15 | pooler → Postgres | pooler가 실제 Postgres에 열 수 있는 최대 커넥션 수. 이 값을 초과하면 쿼리가 대기한다. |
+| Max client connections | 200 | 앱 → pooler | 앱 인스턴스들이 pooler에 동시에 붙을 수 있는 최대 소켓 수. |
+
+우리가 `pool_size=2, max_overflow=3`으로 설정한 근거는 **pooler → Postgres 방향의 15** 한도다. Cloud Run 인스턴스 한 개가 최대 `pool_size + max_overflow = 5` 커넥션을 pooler 쪽으로 열고, `max-instances=3`이므로 최악의 경우 `3 × 5 = 15`로 pooler → Postgres 한도에 딱 맞는다. 인스턴스를 늘리거나 풀 크기를 키우면 이 한도를 초과해 쿼리 대기가 발생한다.
+
+## 6. 결과를 전달하는 영역
+
+- **Cloud Run 서비스** (`seoul-walk-api`): 배포 완료 후 API 트래픽을 처리한다.
+- **프론트엔드·모바일 앱**: 배포된 서비스 엔드포인트를 사용한다.
+- **`scripts/gen_test_token.py`**: 배포 후 로컬에서 테스트 토큰을 생성해 API를 검증한다.
+
+## 7. 변경 시 영향 범위
+
+| 변경 | 함께 확인할 대상 |
+|---|---|
+| `requirements.txt` 의존성 추가·삭제 | Docker 빌드 캐시 무효화, `pyproject.toml`과 동기화 여부 |
+| `artifacts/walk_graph_v1.pkl` 교체 | `WALK_GRAPH_DATA_VERSION`, `WALK_GRAPH_EXPECTED_COMMIT` 값 갱신 필요 |
+| `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` | `max-instances` × (pool_size + max_overflow) ≤ 15 (pooler → Postgres 한도) 초과 여부 확인 |
+| `DB_AUTO_MIGRATE` 모드 변경 | 프로덕션에서 `full`로 바꾸면 컬럼 DROP 위험 — 반드시 backup 후 실행 |
+| Secret Manager 시크릿 이름 변경 | `cloudbuild.yaml`의 `--set-secrets` 값과 동기화 필요 |
+| Cloud Run `--max-instances` 변경 | DB 풀 한도 재계산 필요 |
+| `_AR_REGION` / `_RUN_REGION` 변경 | Artifact Registry URL, Cloud Run 배포 리전 전체 갱신 |
+| `POSTGRES_SSL_MODE` 변경 | 로컬 개발 환경과 혼용 시 SSL 충돌 가능 |
+
+## 8. 실패·복구 방법
+
+| 실패 | 원인 | 복구 |
+|---|---|---|
+| Docker 빌드 실패 | `requirements.txt` 의존성 충돌, `fiona` 외 apt 의존 패키지 | 의존성 버전 고정 확인, apt 레이어 추가 검토 |
+| Artifact Registry push 실패 | IAM 권한 부족 | Cloud Build 서비스 계정에 `artifactregistry.writer` 역할 부여 |
+| Secret Manager 시크릿 누락 | 시크릿 미생성 | `gcloud secrets create` 후 재배포 |
+| Cloud Run 배포 실패 — DB 연결 거부 | `POSTGRES_SSL_MODE`, 호스트, 포트 오설정 | 환경변수 값 재확인 후 재배포 |
+| DB 풀 초과 | `max-instances` × (pool_size + max_overflow) > 15 (pooler → Postgres 한도) | `max-instances` 축소 또는 풀 크기 축소 |
+| 서버 시작 시 컬럼 DROP (프로덕션) | `DB_AUTO_MIGRATE=full`로 잘못 설정 | `create` 모드로 재배포, 삭제된 컬럼은 Supabase 백업에서 복구 |
+| walk graph 불일치 | pkl과 DB link_id 불일치 | `scripts/check_graph_db_consistency.py`로 확인 후 artifact 재빌드 |
+| Cloud Run cold start 지연 | `min-instances=0` | 허용 범위 내면 정상. 개선 필요 시 `min-instances=1` 검토 |
+
+## 9. 검증 방법
+
+### 배포 후 기본 확인
+
+서비스 URL: `https://seoul-walk-api-973252334772.asia-northeast3.run.app`
+
+```bash
+# 헬스체크 (PostgreSQL 연결 여부)
+curl https://seoul-walk-api-973252334772.asia-northeast3.run.app/api/health
+
+# 루트 응답
+curl https://seoul-walk-api-973252334772.asia-northeast3.run.app/
+```
+
+### 테스트 토큰 생성 (인증 API 검증용)
+
+```bash
+# .env에 ACCESS_SECRET_KEY가 있어야 함
+python scripts/gen_test_token.py
+python scripts/gen_test_token.py --provider-id my_id --hours 24
+```
+
+출력 예:
+```
+provider_id : test_9999
+expires_at  : 2026-08-06 20:00 KST
+token       : eyJ...
+```
+
+### walk graph ↔ DB 정합성 확인
+
+```bash
+# 1. DB link_id 목록 추출 (Supabase 또는 로컬 DB에서)
+psql ... -c "COPY (SELECT link_id FROM walk_edge) TO '/tmp/db_link_ids.txt';"
+
+# 2. 정합성 검사
+python scripts/check_graph_db_consistency.py
+# 기대값: ✅ 정합성 OK — 그래프의 모든 link_id가 DB에 존재
+```
+
+### Cloud Build 수동 실행 (배포 트리거 없이 테스트)
+
+```bash
+gcloud builds submit . \
+  --config=cloudbuild.yaml \
+  --substitutions=_TAG=$(git rev-parse --short HEAD)
+```
+
+## 10. 완료 기준
+
+2026-08-03 기준 아래 항목 모두 확인 완료:
+
+- `seoul-walk-api` Cloud Run 서비스 배포 완료 및 운영 중
+- `/api/health` HTTP 200, PostgreSQL 연결 확인
+- 경로 생성 API 동작 확인
+- Kakao 로그인 동작 확인
+- DB 풀 설정 `max-instances(3) × (pool_size(2) + max_overflow(3)) = 15` ≤ Supabase pooler → Postgres 한도(15) 충족
+- `DB_AUTO_MIGRATE=create`로 기동 시 컬럼 DROP 없음 확인
+- Secret Manager 시크릿 10개 주입 상태로 서버 기동 확인
+
+재배포 시 추가로 확인할 항목:
+
+- `gen_test_token.py`로 생성한 토큰으로 인증 필요 API 호출 성공
+- `check_graph_db_consistency.py`로 walk graph ↔ DB link_id 정합성 확인


### PR DESCRIPTION
## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- docs/deployment/README.md 신규 작성 Dockerfile, cloudbuild, Secret Manager, DB 풀 산정 근거, 마이그레이션 모드, 유틸 스크립트, 재배포·롤백·로그 확인 방법
- docs/authentication/README.md ACCESS_TOKEN_EXPIRE_MINUTES, REFRESH_TOKEN_EXPIRE_DAYS 반영 쿠키 Max-Age 불일치 주의 항목 추가
- docs/README.md 문서 인덱스에 deployment/ 추가