### PR TITLE
Feat/331

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -56,6 +56,8 @@ from benchmarks.solvers.rcsp_solver import CircularRcspSolver, OnewayRcspSolver
 from benchmarks.solvers.astar_solver import OnewayAstarSolver
 from benchmarks.solvers.dijkstra_solver import OnewayDijkstraSolver
 from src.route_engine.engines.oneway_astar import precompute_landmarks
+from benchmarks.solvers.bi_astar_solver import OnewayBidirectionalAstarSolver
+from src.route_engine.scoring.scoring_engine import precompute_scoring_features
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +85,7 @@ SOLVER_REGISTRY: dict[str, BasePathSolver] = {
     "rcsp-oneway": OnewayRcspSolver(),
     "plateau": PlateauSolver(),
     "astar-oneway": OnewayAstarSolver(),
+    "bi-astar-oneway": OnewayBidirectionalAstarSolver(),
     "dijkstra-oneway" : OnewayDijkstraSolver(),
     "dummy-a": DummySolver(name="DummySolver-A", fake_delay_sec=0.05),
     "dummy-b": DummySolver(name="DummySolver-B", fake_delay_sec=0.1),
@@ -381,6 +384,12 @@ def parse_args(argv=None) -> argparse.Namespace:
         default=None,
         help="도착 노드 ID. 미지정 시 start-node와 동일(순환 경로 기본값)",
     )
+    parser.add_argument(
+        "--profile",
+        type=str,
+        default=None,
+        help="스코어링 프로필 (default/nature/safe/flat/running/landmark/child/convenient/accessible). 미지정 시 default",
+    )
     return parser.parse_args(argv)
 
 
@@ -438,6 +447,8 @@ def main():
 
     target_node = args.end_node if args.end_node is not None else start_node  # 편도는 --end-node로 별도 지정
     params = {"target_km": args.target_km}
+    if args.profile is not None:
+        params["profile"] = args.profile    
     if args.time_budget is not None:
         params["time_budget_sec"] = args.time_budget
 
@@ -446,6 +457,7 @@ def main():
     if graph is not None and any(isinstance(s, OnewayAstarSolver) for s in solvers):
         logger.info("랜드마크 전처리 중...")
         precompute_landmarks(graph)
+        precompute_scoring_features(graph)
 
     result_df = run_benchmark(solvers, graph, start_node, target_node, params, timeout_sec=args.timeout)
 

--- a/benchmarks/run_all_scenarios.py
+++ b/benchmarks/run_all_scenarios.py
@@ -10,11 +10,8 @@ from benchmarks.benchmark import _load_default_graph, run_benchmark, SOLVER_REGI
 from src.route_engine.engines.path_utils import PathUtils
 from src.route_engine.engines.oneway_astar import precompute_landmarks
 
-# ONEWAY_ALGOS   = ["beam-oneway", "grasp-oneway", "alns-oneway", "rcsp-oneway", "plateau", "astar-oneway", "dijkstra-oneway"]
-# CIRCULAR_ALGOS = ["beam-circular", "grasp-circular", "alns-circular", "rcsp-circular"]
-
-ONEWAY_ALGOS   = ["astar-oneway", "dijkstra-oneway"]
-CIRCULAR_ALGOS = []
+ONEWAY_ALGOS   = ["beam-oneway", "grasp-oneway", "alns-oneway", "rcsp-oneway", "plateau", "astar-oneway", "bi-astar-oneway", "dijkstra-oneway"]
+CIRCULAR_ALGOS = ["beam-circular", "grasp-circular", "alns-circular", "rcsp-circular"]
 
 def main():
     print("그래프 로딩 중...", flush=True)
@@ -31,7 +28,7 @@ def main():
     with open(ROUTE_ENGINE_DATASET, encoding="utf-8") as f:
         dataset = json.load(f)
 
-    scenarios = dataset["scenarios"]
+    scenarios = dataset["scenarios"][:1]
     print(f"시나리오 {len(scenarios)}개 테스트 (oneway {sum(1 for s in scenarios if s['mode']=='oneway')}개, circular {sum(1 for s in scenarios if s['mode']=='circular')}개)\n", flush=True)
 
     all_rows = []
@@ -79,7 +76,7 @@ def main():
 
     print(summary.to_string())
     
-    TARGET_AGNOSTIC_ALGOS = {"A*(oneway)", "Dijkstra(oneway)"}  # target_km을 안 쓰는 순수 최단경로 solver
+    TARGET_AGNOSTIC_ALGOS = {"A*(oneway)", "Dijkstra(oneway)", "Bidirectional A*(oneway)"}  # target_km을 안 쓰는 순수 최단경로 solver
     hit = TARGET_AGNOSTIC_ALGOS & set(summary.index)
     if hit:
         print(

--- a/benchmarks/solvers/_oneway_engine_common.py
+++ b/benchmarks/solvers/_oneway_engine_common.py
@@ -48,7 +48,8 @@ def base_shortest_path_overlap_ratio(engine, pruned_path: list, start_node: int,
     (benchmark.py의 edge_overlap_ratio는 '자기 자신과의 왕복 중복'이라 다른 지표임).
     """
     try:
-        base_path = nx.shortest_path(engine.G, start_node, end_node, weight="custom_score")
+        weight = getattr(engine, "_weight_fn", None) or "custom_score"
+        base_path = nx.shortest_path(engine.G, start_node, end_node, weight=weight)
     except nx.NetworkXNoPath:
         return 0.0
 

--- a/benchmarks/solvers/astar_solver.py
+++ b/benchmarks/solvers/astar_solver.py
@@ -1,7 +1,7 @@
 from benchmarks.solvers._oneway_engine_common import base_shortest_path_overlap_ratio
 from benchmarks.solvers.base_solver import BasePathSolver
 from src.route_engine.engines.oneway_astar import OnewayAstarEngine
-from src.route_engine.scoring.scoring_engine import calculate_custom_score
+from src.route_engine.scoring.scoring_engine import compute_custom_score_lookup
 from src.schema.route_schema import OnewayRouteInput
 import time
 
@@ -26,21 +26,23 @@ class OnewayAstarSolver(BasePathSolver):
             profile=params.get("profile"),
         )
         t1 = time.perf_counter()
-        calculate_custom_score(engine.G, {
+        scored = compute_custom_score_lookup(engine.G, {
             "mode": engine.scoring_mode,
             "weights": engine.weights,
             "blocked_tags": engine.blocked_tags,
         })
-        engine._min_ratio = engine._min_cost_per_m()
+        engine._weight_fn    = scored["weight"]
+        engine._score_lookup = scored["lookup"]
+        engine._min_ratio    = scored["min_ratio"]
         t2 = time.perf_counter()
 
         nodes = engine.find_path(start_node, target_node)
         t3 = time.perf_counter()
-        print(f"[A* 진단] G.copy={t1-t0:.3f}s, custom_score+min_ratio={t2-t1:.3f}s, find_path={t3-t2:.3f}s")
+        print(f"[A* 진단] G.assign={t1-t0:.3f}s, custom_score+min_ratio={t2-t1:.3f}s, find_path={t3-t2:.3f}s")
 
         if not nodes or len(nodes) < 2:
             raise ValueError("경로 생성 실패: 유효한 편도 경로를 찾지 못했습니다 (NO_PATH)")
 
-        _, cost = engine.utils.metrics(nodes)
+        cost = engine.path_cost(nodes)
         overlap_ratio = base_shortest_path_overlap_ratio(engine, nodes, start_node, target_node)
         return {"paths": [nodes], "cost": cost, "overlap_ratio": overlap_ratio}

--- a/benchmarks/solvers/bi_astar_solver.py
+++ b/benchmarks/solvers/bi_astar_solver.py
@@ -1,0 +1,48 @@
+from benchmarks.solvers._oneway_engine_common import base_shortest_path_overlap_ratio
+from benchmarks.solvers.base_solver import BasePathSolver
+from src.route_engine.engines.oneway_bi_astar import OnewayBidirectionalAstarEngine
+from src.route_engine.scoring.scoring_engine import compute_custom_score_lookup
+from src.schema.route_schema import OnewayRouteInput
+import time
+
+_DEFAULT_TARGET_KM = 3.0
+
+
+class OnewayBidirectionalAstarSolver(BasePathSolver):
+    def __init__(self, name: str = "Bidirectional A*(oneway)"):
+        super().__init__(name)
+
+    def solve(self, graph, start_node, target_node, params: dict) -> dict:
+        target_km = params.get("target_km") or _DEFAULT_TARGET_KM
+        inp = OnewayRouteInput(
+            start_lat=0.0, start_lon=0.0, end_lat=0.0, end_lon=0.0, target_km=target_km,
+        )
+
+        t0 = time.perf_counter()
+        engine = OnewayBidirectionalAstarEngine(
+            inp=inp,
+            G=graph,
+            custom_weights=params.get("custom_weights"),
+            profile=params.get("profile"),
+        )
+        t1 = time.perf_counter()
+        scored = compute_custom_score_lookup(engine.G, {
+            "mode": engine.scoring_mode,
+            "weights": engine.weights,
+            "blocked_tags": engine.blocked_tags,
+        })
+        engine._weight_fn    = scored["weight"]
+        engine._score_lookup = scored["lookup"]
+        engine._min_ratio    = scored["min_ratio"]
+        t2 = time.perf_counter()
+
+        nodes = engine.find_path(start_node, target_node)
+        t3 = time.perf_counter()
+        print(f"[Bi-A* 진단] G.assign={t1-t0:.3f}s, custom_score+min_ratio={t2-t1:.3f}s, find_path={t3-t2:.3f}s")
+
+        if not nodes or len(nodes) < 2:
+            raise ValueError("경로 생성 실패: 유효한 편도 경로를 찾지 못했습니다 (NO_PATH)")
+
+        cost = engine.path_cost(nodes)
+        overlap_ratio = base_shortest_path_overlap_ratio(engine, nodes, start_node, target_node)
+        return {"paths": [nodes], "cost": cost, "overlap_ratio": overlap_ratio}

--- a/benchmarks/solvers/dijkstra_solver.py
+++ b/benchmarks/solvers/dijkstra_solver.py
@@ -8,7 +8,7 @@ src/route_engine/engines/dijkstra.py (OnewayDijkstraEngine)를 BasePathSolver �
 from benchmarks.solvers._oneway_engine_common import base_shortest_path_overlap_ratio
 from benchmarks.solvers.base_solver import BasePathSolver
 from src.route_engine.engines.dijkstra import OnewayDijkstraEngine
-from src.route_engine.scoring.scoring_engine import calculate_custom_score
+from src.route_engine.scoring.scoring_engine import compute_custom_score_lookup
 from src.schema.route_schema import OnewayRouteInput
 
 _DEFAULT_TARGET_KM = 3.0
@@ -30,16 +30,18 @@ class OnewayDijkstraSolver(BasePathSolver):
             custom_weights=params.get("custom_weights"),
             profile=params.get("profile"),
         )
-        calculate_custom_score(engine.G, {
+        scored = compute_custom_score_lookup(engine.G, {
             "mode": engine.scoring_mode,
             "weights": engine.weights,
             "blocked_tags": engine.blocked_tags,
         })
+        engine._weight_fn    = scored["weight"]
+        engine._score_lookup = scored["lookup"]
 
         nodes = engine.find_path(start_node, target_node)
         if not nodes or len(nodes) < 2:
             raise ValueError("경로 생성 실패: 유효한 편도 경로를 찾지 못했습니다 (NO_PATH)")
 
-        _, cost = engine.utils.metrics(nodes)
+        cost = engine.path_cost(nodes)
         overlap_ratio = base_shortest_path_overlap_ratio(engine, nodes, start_node, target_node)
         return {"paths": [nodes], "cost": cost, "overlap_ratio": overlap_ratio}

--- a/src/interfaces/dependencies.py
+++ b/src/interfaces/dependencies.py
@@ -28,6 +28,7 @@ from src.repository.network.graph_artifact_repository import (
     GraphArtifactRepository,
 )
 from src.repository.network.graph_repository import GraphRepository
+from src.route_engine.scoring.scoring_engine import precompute_scoring_features
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,7 @@ def load_runtime_graph():
 def init_route_service():
     global G, route_service, prewalk_orchestrator
     G             = load_runtime_graph()
+    precompute_scoring_features(G)
     route_service = RouteService(G=G, auth_service=auth_service)
     prewalk_orchestrator = PrewalkOrchestrator(
         weather_checker        = WeatherChecker(weather_client=weather_client),

--- a/src/route_engine/engines/dijkstra.py
+++ b/src/route_engine/engines/dijkstra.py
@@ -10,7 +10,7 @@ from src.interfaces.schema.walk_schema import (
     WalkRouteResponse
 )
 from src.schema.route_schema import OnewayRouteInput, Weights
-from src.route_engine.scoring.scoring_engine import calculate_custom_score
+from src.route_engine.scoring.scoring_engine import compute_custom_score_lookup
 
 logger = logging.getLogger(__name__)
 
@@ -23,13 +23,15 @@ class OnewayDijkstraEngine:
         profile: Optional[ScoringProfile] = None,
     ):
         self.inp           = inp
-        self.G             = G.copy()  # 원본 그래프 보호
+        self.G             = G  # custom_score를 그래프에 쓰지 않으므로 copy() 불필요
         self.utils         = PathUtils(self.G)
         self.mode          = WalkMode.ONEWAY_SHORTEST
         profile_config     = get_profile(profile)
         self.weights       = merge_weights(profile_config.weights, custom_weights)
         self.blocked_tags  = profile_config.blocked_tags
         self.scoring_mode  = profile_config.scoring_mode
+        self._weight_fn    = None
+        self._score_lookup: dict = {}
 
     def run(self) -> WalkRouteResponse:
         """
@@ -37,52 +39,42 @@ class OnewayDijkstraEngine:
         """
         logger.info(f"최단 경로 생성 엔진을 시작합니다: scoring_mode={self.scoring_mode}, weights={self.weights}")
 
-        # 엣지별 custom_score 기록 (in-place)
-        calculate_custom_score(self.G, {
+        scored = compute_custom_score_lookup(self.G, {
             "mode": self.scoring_mode,
             "weights": self.weights,
             "blocked_tags": self.blocked_tags,
         })
+        self._weight_fn    = scored["weight"]
+        self._score_lookup = scored["lookup"]
 
-        # 출발 노드와 도착 노드 탐색
         start = self.utils.find_nearest_node(self.inp.start_lat, self.inp.start_lon)
         end   = self.utils.find_nearest_node(self.inp.end_lat,   self.inp.end_lon)
 
-        # 출발 노드가 없는 경우
         if start is None:
             logger.warning("출발 노드를 찾지 못했습니다.")
             return WalkRouteResponse(
                 status=WalkRouteStatus.NO_NEAREST_START_NODE,
-                mode=self.mode,
-                coordinates=[],
-                total_km=0.0,
+                mode=self.mode, coordinates=[], total_km=0.0,
             )
-        
-        # 도착 노드가 없는 경우
+
         if end is None:
             logger.warning("도착 노드를 찾지 못했습니다.")
             return WalkRouteResponse(
                 status=WalkRouteStatus.NO_NEAREST_END_NODE,
-                mode=self.mode,
-                coordinates=[],
-                total_km=0.0,
+                mode=self.mode, coordinates=[], total_km=0.0,
             )
-        
-        # 경로 생성
+
         nodes = self.find_path(start, end)
 
-        # 경로가 없는 경우
         if not nodes:
             logger.warning("경로가 비어 있습니다.")
             return WalkRouteResponse(
                 status=WalkRouteStatus.NO_PATH,
-                mode=self.mode,
-                coordinates=[],
-                total_km=0.0,
+                mode=self.mode, coordinates=[], total_km=0.0,
             )
 
-        coords    = self.utils.extract_coordinates(nodes)  # [lat, lon] 좌표 목록
-        total_m   = self.utils.calc_distance(nodes)        # 총 이동 거리(m)
+        coords    = self.utils.extract_coordinates(nodes)
+        total_m   = self.utils.calc_distance(nodes)
         total_km = round(total_m / 1000, 2)
 
         logger.info(f"total_km: {total_km}")
@@ -99,10 +91,17 @@ class OnewayDijkstraEngine:
         Dijkstra 알고리즘으로 최단 경로 노드 목록을 반환합니다.
         """
         try:
-            return nx.shortest_path(self.G, start, end, weight="custom_score")
+            return nx.shortest_path(self.G, start, end, weight=self._weight_fn)
         except nx.NetworkXNoPath:
             logger.warning("출발-도착 노드 사이에 연결된 경로가 없습니다")
             return []
         except Exception:
-            logger.exception("최단 경로 생성에에 실패했습니다")
+            logger.exception("최단 경로 생성에 실패했습니다")
             return []
+
+    def path_cost(self, path: list[int]) -> float:
+        """경로(노드 리스트)의 누적 custom_score. 벤치마크 solver의 cost 계산용."""
+        return sum(
+            self._score_lookup.get((path[i], path[i + 1]), 1.0)
+            for i in range(len(path) - 1)
+        )

--- a/src/route_engine/engines/oneway_astar.py
+++ b/src/route_engine/engines/oneway_astar.py
@@ -10,10 +10,9 @@ from src.interfaces.schema.walk_schema import (
     WalkRouteResponse
 )
 from src.schema.route_schema import OnewayRouteInput, Weights
-from src.route_engine.scoring.scoring_engine import calculate_custom_score
+from src.route_engine.scoring.scoring_engine import compute_custom_score_lookup
 
 logger = logging.getLogger(__name__)
-_NUM_LANDMARKS = 8  # 그래프 경계 8방향(동서남북+대각선) 기준
 
 class OnewayAstarEngine:
     def __init__(
@@ -24,13 +23,16 @@ class OnewayAstarEngine:
         profile: Optional[ScoringProfile] = None,
     ):
         self.inp           = inp
-        self.G             = G.copy()  # 원본 그래프 보호
+        self.G             = G  # custom_score를 그래프에 쓰지 않으므로 copy() 불필요
         self.utils         = PathUtils(self.G)
         self.mode          = WalkMode.ONEWAY_SHORTEST
         profile_config     = get_profile(profile)
         self.weights       = merge_weights(profile_config.weights, custom_weights)
         self.blocked_tags  = profile_config.blocked_tags
         self.scoring_mode  = profile_config.scoring_mode
+        self._weight_fn    = None
+        self._score_lookup: dict = {}
+        self._min_ratio    = 1.0
 
     def run(self) -> WalkRouteResponse:
         """
@@ -38,54 +40,44 @@ class OnewayAstarEngine:
         """
         logger.info(f"최단 경로 생성 엔진(A*)을 시작합니다: scoring_mode={self.scoring_mode}, weights={self.weights}")
 
-        # 엣지별 custom_score 기록 (in-place)
-        calculate_custom_score(self.G, {
+        scored = compute_custom_score_lookup(self.G, {
             "mode": self.scoring_mode,
             "weights": self.weights,
             "blocked_tags": self.blocked_tags,
         })
-        self._min_ratio = self._min_cost_per_m()  # A* admissibility용 최소 비용/거리 비율
-
+        self._weight_fn    = scored["weight"]
+        self._score_lookup = scored["lookup"]
+        self._min_ratio    = scored["min_ratio"]
 
         # 출발 노드와 도착 노드 탐색
         start = self.utils.find_nearest_node(self.inp.start_lat, self.inp.start_lon)
         end   = self.utils.find_nearest_node(self.inp.end_lat,   self.inp.end_lon)
 
-        # 출발 노드가 없는 경우
         if start is None:
             logger.warning("출발 노드를 찾지 못했습니다.")
             return WalkRouteResponse(
                 status=WalkRouteStatus.NO_NEAREST_START_NODE,
-                mode=self.mode,
-                coordinates=[],
-                total_km=0.0,
+                mode=self.mode, coordinates=[], total_km=0.0,
             )
 
-        # 도착 노드가 없는 경우
         if end is None:
             logger.warning("도착 노드를 찾지 못했습니다.")
             return WalkRouteResponse(
                 status=WalkRouteStatus.NO_NEAREST_END_NODE,
-                mode=self.mode,
-                coordinates=[],
-                total_km=0.0,
+                mode=self.mode, coordinates=[], total_km=0.0,
             )
 
-        # 경로 생성
         nodes = self.find_path(start, end)
 
-        # 경로가 없는 경우
         if not nodes:
             logger.warning("경로가 비어 있습니다.")
             return WalkRouteResponse(
                 status=WalkRouteStatus.NO_PATH,
-                mode=self.mode,
-                coordinates=[],
-                total_km=0.0,
+                mode=self.mode, coordinates=[], total_km=0.0,
             )
 
-        coords    = self.utils.extract_coordinates(nodes)  # [lat, lon] 좌표 목록
-        total_m   = self.utils.calc_distance(nodes)        # 총 이동 거리(m)
+        coords    = self.utils.extract_coordinates(nodes)
+        total_m   = self.utils.calc_distance(nodes)
         total_km = round(total_m / 1000, 2)
 
         logger.info(f"total_km: {total_km}")
@@ -102,12 +94,11 @@ class OnewayAstarEngine:
         A* 알고리즘으로 최단 경로 노드 목록을 반환합니다.
         """
         try:
-            path = nx.astar_path(
+            return nx.astar_path(
                 self.G, start, end,
                 heuristic=self._heuristic,
-                weight="custom_score",
+                weight=self._weight_fn,
             )
-            return path
         except nx.NetworkXNoPath:
             logger.warning("출발-도착 노드 사이에 연결된 경로가 없습니다")
             return []
@@ -115,31 +106,27 @@ class OnewayAstarEngine:
             logger.exception("최단 경로 생성에 실패했습니다")
             return []
 
-    def _min_cost_per_m(self) -> float:
-        """
-        그래프 전체에서 (custom_score / length)의 최솟값.
-        직선거리(m) × 이 값은 항상 실제 비용의 하한 — A* admissibility 보장용.
-        """
-        return min(
-            (data.get("custom_score", 1.0) / max(data.get("length", 1.0) or 1.0, 1e-6))
-            for _, _, data in self.G.edges(data=True)
+    def path_cost(self, path: list[int]) -> float:
+        """경로(노드 리스트)의 누적 custom_score. 벤치마크 solver의 cost 계산용."""
+        return sum(
+            self._score_lookup.get((path[i], path[i + 1]), 1.0)
+            for i in range(len(path) - 1)
         )
 
     def _heuristic(self, node: int, target: int) -> float:
         """
         A* 휴리스틱: 랜드마크 삼각부등식 기반 도로망거리 추정 × 최소 비용/거리 비율.
         """
-        self._heuristic_calls = getattr(self, "_heuristic_calls", 0) + 1
         d_node   = self.G.nodes[node]["landmark_dist"]
         d_target = self.G.nodes[target]["landmark_dist"]
         network_est = max(abs(a - b) for a, b in zip(d_node, d_target))
         return network_est * self._min_ratio
-    
+
+
 def precompute_landmarks(G: nx.Graph) -> None:
     """
     그래프 경계 근처 8개 노드를 랜드마크로 선정하고, 각 랜드마크에서 전체 노드까지의
     실제 도로망 거리(m, length 기준 — 프로필 무관)를 미리 계산해 노드 속성에 저장합니다.
-    A* 휴리스틱에서 삼각부등식 기반 하한(ALT)으로 사용합니다.
     그래프 로드 시 한 번만 호출하면 되고, 프로필이 달라져도 재계산할 필요 없습니다.
     """
     landmarks = _select_landmarks(G)

--- a/src/route_engine/engines/oneway_bi_astar.py
+++ b/src/route_engine/engines/oneway_bi_astar.py
@@ -1,0 +1,93 @@
+# src/route_engine/engines/oneway_bi_astar.py
+import heapq
+from itertools import count
+from typing import Callable
+
+import networkx as nx
+
+from src.route_engine.engines.oneway_astar import OnewayAstarEngine
+
+logger = __import__("logging").getLogger(__name__)
+
+
+def _bidirectional_astar_path(
+    G: nx.Graph,
+    source: int,
+    target: int,
+    heuristic: Callable[[int, int], float],
+    weight: Callable[[int, int, dict], float],
+):
+    """
+    일관된 이중 potential(pf/pr)을 이용한 양방향 A*.
+    G는 무방향 그래프라고 가정 — 역방향 탐색도 동일한 인접 구조를 사용.
+    weight는 networkx 관례와 동일한 콜러블(u, v, edge_data) -> float.
+    """
+    if source == target:
+        return [source], 0.0
+
+    def pf(v: int) -> float:
+        return (heuristic(v, target) - heuristic(source, v)) / 2
+
+    def pr(v: int) -> float:
+        return -pf(v)
+
+    push, pop, c = heapq.heappush, heapq.heappop, count()
+
+    dists  = [{}, {}]
+    seen   = [{source: 0.0}, {target: 0.0}]
+    paths  = [{source: [source]}, {target: [target]}]
+    fringe = [[], []]
+    push(fringe[0], (pf(source), next(c), source))
+    push(fringe[1], (pr(target), next(c), target))
+
+    finalpath, finaldist = [], float("inf")
+    dir_ = 1
+    while fringe[0] and fringe[1]:
+        dir_ = 1 - dir_
+        _, _, v = pop(fringe[dir_])
+        if v in dists[dir_]:
+            continue
+        dists[dir_][v] = seen[dir_][v]
+
+        if finaldist < float("inf") and fringe[0] and fringe[1]:
+            if fringe[0][0][0] + fringe[1][0][0] >= finaldist:
+                break
+
+        for w, edata in G[v].items():
+            if w in dists[dir_]:
+                continue
+            vw_len = seen[dir_][v] + weight(v, w, edata)
+            if w not in seen[dir_] or vw_len < seen[dir_][w]:
+                seen[dir_][w] = vw_len
+                priority = vw_len + (pf(w) if dir_ == 0 else pr(w))
+                push(fringe[dir_], (priority, next(c), w))
+                paths[dir_][w] = paths[dir_][v] + [w]
+
+                if w in seen[0] and w in seen[1]:
+                    total = seen[0][w] + seen[1][w]
+                    if total < finaldist:
+                        finaldist = total
+                        finalpath = paths[0][w][:-1] + list(reversed(paths[1][w]))
+
+    if finaldist == float("inf"):
+        raise nx.NetworkXNoPath(f"No path between {source} and {target}.")
+    return finalpath, finaldist
+
+
+class OnewayBidirectionalAstarEngine(OnewayAstarEngine):
+    """OnewayAstarEngine과 동일한 인터페이스, 탐색만 양방향 A*로 교체."""
+
+    def find_path(self, start: int, end: int) -> list[int]:
+        try:
+            path, _ = _bidirectional_astar_path(
+                self.G, start, end,
+                heuristic=self._heuristic,
+                weight=self._weight_fn,
+            )
+            return path
+        except nx.NetworkXNoPath:
+            logger.warning("출발-도착 노드 사이에 연결된 경로가 없습니다")
+            return []
+        except Exception:
+            logger.exception("최단 경로 생성에 실패했습니다")
+            return []

--- a/src/route_engine/scoring/scoring_engine.py
+++ b/src/route_engine/scoring/scoring_engine.py
@@ -1,6 +1,7 @@
 import math
 
 import networkx as nx
+import numpy as np
 
 
 COMFORT_TAG_PENALTIES = {
@@ -10,128 +11,176 @@ COMFORT_TAG_PENALTIES = {
     "building_inside": 1.08,
 }
 
-
-def _clamp_score(value, default: float = 0.0) -> float:
-    if value is None:
-        return default
-    return max(0.0, min(1.0, float(value)))
+_FEATURE_CACHE_KEY = "_scoring_feature_cache"
 
 
-def _bounded_count_score(count, saturation_count: int) -> float:
-    """POI 개수를 0~1로 제한하며 saturation_count에서 상한에 도달시킵니다."""
-    safe_count = max(0, int(count or 0))
-    return min(
-        1.0,
-        math.log1p(safe_count) / math.log1p(saturation_count),
-    )
+def _clamp_score_arr(arr: np.ndarray) -> np.ndarray:
+    return np.clip(np.nan_to_num(arr, nan=0.0), 0.0, 1.0)
 
 
-def calculate_custom_score(graph: nx.Graph, profile: dict) -> nx.Graph:
+def _bounded_count_score_arr(count_arr: np.ndarray, saturation_count: int) -> np.ndarray:
+    safe = np.maximum(0, count_arr.astype(np.int64))
+    return np.minimum(1.0, np.log1p(safe) / math.log1p(saturation_count))
+
+
+def _build_feature_cache(graph: nx.Graph) -> dict:
+    edges = list(graph.edges(data=True))
+    n = len(edges)
+
+    edge_keys = [(u, v) for u, v, _ in edges]
+    length_raw = np.empty(n, dtype=np.float64)
+    safety_raw = np.empty(n, dtype=np.float64)
+    nature_raw = np.empty(n, dtype=np.float64)
+    park_raw = np.empty(n, dtype=np.float64)
+    slope_raw = np.empty(n, dtype=np.float64)
+    landmark_raw = np.empty(n, dtype=np.float64)
+    running_raw = np.empty(n, dtype=np.float64)
+    convenience_raw = np.empty(n, dtype=np.float64)
+    toilet_count = np.empty(n, dtype=np.int64)
+    transit_count = np.empty(n, dtype=np.int64)
+    accessibility_count = np.empty(n, dtype=np.int64)
+    is_vehicle_caution = np.empty(n, dtype=bool)
+    comfort_penalty = np.ones(n, dtype=np.float64)
+    tags_list: list[list[str]] = []
+
+    for i, (_, _, data) in enumerate(edges):
+        length_raw[i] = max(1.0, float(data.get("length", 1.0) or 1.0))
+        safety_raw[i] = data.get("safety_score") or 0.0
+        nature_raw[i] = data.get("nature_score") or 0.0
+        park_raw[i] = data.get("park_overlap_ratio") or 0.0
+        slope_raw[i] = data.get("slope_score") or 0.0
+        landmark_raw[i] = data.get("landmark_score") or 0.0
+        running_raw[i] = data.get("running_score") or 0.0
+        convenience_raw[i] = data.get("convenience_score") or 0.0
+        toilet_count[i] = int(data.get("toilet_count", 0) or 0)
+        transit_count[i] = int(data.get("transit_count", 0) or 0)
+        accessibility_count[i] = int(data.get("accessibility_poi_count", 0) or 0)
+        is_vehicle_caution[i] = bool(data.get("is_vehicle_caution", False))
+
+        tags = data.get("tags", []) or []
+        tags_list.append(tags)
+        for tag, penalty in COMFORT_TAG_PENALTIES.items():
+            if tag in tags:
+                comfort_penalty[i] = max(comfort_penalty[i], penalty)
+
+    convenience_poi = _bounded_count_score_arr(toilet_count + transit_count, saturation_count=3)
+
+    return {
+        "edge_keys": edge_keys,
+        "length": length_raw,
+        "safety": _clamp_score_arr(safety_raw),
+        "nature": np.maximum(_clamp_score_arr(nature_raw), _clamp_score_arr(park_raw)),
+        "slope": _clamp_score_arr(slope_raw),
+        "landmark": _clamp_score_arr(landmark_raw),
+        "running": _clamp_score_arr(running_raw),
+        "convenience": np.maximum(_clamp_score_arr(convenience_raw), convenience_poi),
+        "accessibility": _bounded_count_score_arr(accessibility_count, saturation_count=2),
+        "is_vehicle_caution": is_vehicle_caution,
+        "comfort_penalty": comfort_penalty,
+        "tags_list": tags_list,
+    }
+
+
+def precompute_scoring_features(graph: nx.Graph) -> None:
+    graph.graph[_FEATURE_CACHE_KEY] = _build_feature_cache(graph)
+
+
+def _get_feature_cache(graph: nx.Graph) -> dict:
+    cache = graph.graph.get(_FEATURE_CACHE_KEY)
+    if cache is None or len(cache["edge_keys"]) != graph.number_of_edges():
+        cache = _build_feature_cache(graph)
+        graph.graph[_FEATURE_CACHE_KEY] = cache
+    return cache
+
+
+def _compute_scores_array(graph: nx.Graph, profile: dict) -> tuple[list[tuple], np.ndarray, dict]:
     """
-    graph 각 edge의 feature와 profile 가중치를 곱해 custom_score를 계산하여 부여합니다.
-
-    양의 근거는 (1 + score × weight) 가점으로 사용하여 데이터가 없는
-    지역(score=0)을 감점하지 않습니다. 경사·차량 주의·불쾌 구간은
-    분자에 페널티로 반영합니다.
-
-    주의:
-        Dijkstra는 음수 비용에 취약하므로 custom_score는 최소 1.0으로 보정합니다.
-        blocked_tags가 포함된 edge는 inf로 설정하여 탐색에서 제외합니다.
-
-    Args:
-        graph   : feature들이 바인딩된 NetworkX 그래프
-        profile : {
-            "mode"         : "general" | "running"  (기본값: "general")
-            "weights"      : Weights 객체 또는 dict
-            "blocked_tags" : [str, ...]
-        }
-
-    Returns:
-        custom_score 속성이 추가된 graph
+    calculate_custom_score / compute_custom_score_lookup가 공유하는 계산 코어.
+    그래프에 아무것도 쓰지 않고 (edge_keys, custom_score 배열, feature cache)만 반환한다.
     """
     mode         = profile.get("mode", "general")
     weights      = profile.get("weights", {})
     blocked_tags = profile.get("blocked_tags", [])
 
-    # Weights Pydantic 객체와 dict 모두 수용
     def _w(key: str, default: float = 0.0) -> float:
         if isinstance(weights, dict):
             return weights.get(key, default)
         return getattr(weights, key, default)
 
-    safety_w   = _w("safety",   1.0)
-    nature_w   = _w("nature",   1.0)
-    slope_w    = _w("slope",    1.0)
-    landmark_w = _w("landmark", 0.0)
-    child_w    = _w("child",    0.0)
-    running_w  = _w("running",  0.0)
-    convenience_w = _w("convenience", 0.0)
+    safety_w        = _w("safety",   1.0)
+    nature_w        = _w("nature",   1.0)
+    slope_w         = _w("slope",    1.0)
+    landmark_w      = _w("landmark", 0.0)
+    child_w         = _w("child",    0.0)
+    running_w       = _w("running",  0.0)
+    convenience_w   = _w("convenience", 0.0)
     accessibility_w = _w("accessibility", 0.0)
 
-    for u, v, data in graph.edges(data=True):
-        if blocked_tags and any(tag in data.get("tags", []) for tag in blocked_tags):
-            graph[u][v]["custom_score"] = float("inf")
-            continue
+    cache = _get_feature_cache(graph)
 
-        length = max(1.0, float(data.get("length", 1.0) or 1.0))
-        safety = _clamp_score(data.get("safety_score"))
-        nature = max(
-            _clamp_score(data.get("nature_score")),
-            _clamp_score(data.get("park_overlap_ratio")),
-        )
-        slope = _clamp_score(data.get("slope_score"))
-        landmark = _clamp_score(data.get("landmark_score"))
-        running = _clamp_score(data.get("running_score"))
+    bonus = (
+        (1.0 + cache["safety"] * safety_w)
+        * (1.0 + cache["nature"] * nature_w)
+        * (1.0 + cache["landmark"] * landmark_w)
+        * (1.0 + cache["convenience"] * convenience_w)
+        * (1.0 + cache["accessibility"] * accessibility_w)
+    )
+    slope_penalty = 1.0 + (1.0 - cache["slope"]) * slope_w
+    caution_penalty = np.where(cache["is_vehicle_caution"], 1.0 + child_w, 1.0)
+    comfort_penalty = cache["comfort_penalty"]
 
-        convenience_poi = _bounded_count_score(
-            int(data.get("toilet_count", 0) or 0)
-            + int(data.get("transit_count", 0) or 0),
-            saturation_count=3,
-        )
-        convenience = max(
-            _clamp_score(data.get("convenience_score")),
-            convenience_poi,
-        )
-        accessibility = _bounded_count_score(
-            data.get("accessibility_poi_count", 0),
-            saturation_count=2,
-        )
+    if mode == "running":
+        bonus = bonus * (1.0 + cache["running"] * running_w)
+        bonus = bonus * (1.0 + np.log1p(cache["length"] / 50.0))
 
-        bonus = (
-            (1.0 + safety * safety_w)
-            * (1.0 + nature * nature_w)
-            * (1.0 + landmark * landmark_w)
-            * (1.0 + convenience * convenience_w)
-            * (1.0 + accessibility * accessibility_w)
+    calculated = (
+        cache["length"] * slope_penalty * caution_penalty * comfort_penalty
+    ) / np.maximum(bonus, 1e-6)
+    custom_score = np.maximum(1.0, calculated)
+
+    if blocked_tags:
+        blocked_mask = np.array(
+            [any(tag in tags for tag in blocked_tags) for tags in cache["tags_list"]],
+            dtype=bool,
         )
-        # slope_score는 경사도가 아니라 평탄도입니다.
-        # 1.0은 평지, 0.0은 MAX_SLOPE_PCT 이상의 급경사를 뜻합니다.
-        slope_penalty = 1.0 + (1.0 - slope) * slope_w
-        caution_penalty = (
-            1.0 + child_w
-            if data.get("is_vehicle_caution", False)
-            else 1.0
-        )
-        comfort_penalty = max(
-            (
-                penalty
-                for tag, penalty in COMFORT_TAG_PENALTIES.items()
-                if tag in data.get("tags", [])
-            ),
-            default=1.0,
-        )
+        custom_score = np.where(blocked_mask, np.inf, custom_score)
 
-        if mode == "running":
-            bonus *= 1.0 + running * running_w
-            bonus *= 1.0 + math.log1p(length / 50.0)
+    return cache["edge_keys"], custom_score, cache
 
-        calculated = (
-            length
-            * slope_penalty
-            * caution_penalty
-            * comfort_penalty
-        ) / max(bonus, 1e-6)
 
-        graph[u][v]["custom_score"] = max(1.0, calculated)
-
+def calculate_custom_score(graph: nx.Graph, profile: dict) -> nx.Graph:
+    """
+    기존 동작 유지 — beam/grasp/alns/rcsp/plateau 등 그래프 mutation에 의존하는
+    엔진들을 위해 그대로 남겨둔다. A*/Dijkstra/Bi-A*는 이제 이 함수 대신
+    compute_custom_score_lookup을 쓴다.
+    """
+    edge_keys, custom_score, _ = _compute_scores_array(graph, profile)
+    graph.graph["_last_custom_score_array"] = custom_score
+    for (u, v), score in zip(edge_keys, custom_score.tolist()):
+        graph[u][v]["custom_score"] = score
     return graph
+
+
+def compute_custom_score_lookup(graph: nx.Graph, profile: dict) -> dict:
+    """
+    calculate_custom_score와 동일한 계산이지만 그래프에 쓰지 않는다.
+    G.copy() 없이(원본을 전혀 건드리지 않고) 매 요청 다른 가중치로 반복 계산할 때 사용.
+
+    반환:
+        {"weight": callable(u, v, data) -> float,  # nx.astar_path/shortest_path의 weight= 인자로 그대로 사용
+         "lookup": {(u, v): score, ...},           # 경로 비용 직접 합산용
+         "min_ratio": float}                       # A* admissibility 하한 비율
+    """
+    edge_keys, custom_score, cache = _compute_scores_array(graph, profile)
+
+    lookup: dict[tuple, float] = {}
+    for (u, v), score in zip(edge_keys, custom_score.tolist()):
+        lookup[(u, v)] = score
+        lookup[(v, u)] = score  # 무방향 그래프이므로 양방향 조회 등록
+
+    min_ratio = float(np.min(custom_score / np.maximum(cache["length"], 1e-6)))
+
+    def _weight(u, v, d, _lookup=lookup):
+        return _lookup.get((u, v), 1.0)
+
+    return {"weight": _weight, "lookup": lookup, "min_ratio": min_ratio}


### PR DESCRIPTION
## ☝️Issue Number
- resolve #331 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 단방향 A*는 휴리스틱 계산 비용이 붙고 양방향 A*는 휴리스틱 계산 비용이 2배로 붙는다.
- 따라서 기존의 양방향 dijkstra가 단순한 로직으로 더 빠른 속도를 낼 수 있다. 
- 실제로 A*와 dijkstra 모두에 오버헤드를 증가시키고 있던 부분은 준비 단계였다. (매 쿼리마다 그래프 복사 후 전체 재스코어링)
- 개선 후에는 원본 그래프를 그대로 참조하며 그래프에 적는 대신 numpy 벡터 연산으로 미리 뽑아 저장한 후 매 쿼리 이 배열을 재사용해서 가중치만 곱해 넣는 벡터 연산만 새로 하게 된다.
- 개선 결과로 기존 시나리오 테스트 결과 2~3초 대에서 1초 대로 성능이 현격히 좋아진 것을 확인했다.
