### PR TITLE
Feat/335

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -66,6 +66,7 @@ RESULT_COLUMNS = [
     "cost", "overlap_ratio",
     "distance_km", "target_km", "distance_deviation_km",
     "is_closed_loop", "spike_count", "edge_overlap_ratio",
+    "find_path_sec",
     "error",
 ]
 REQUIRED_RESULT_KEYS = ("paths", "cost")
@@ -131,7 +132,11 @@ def _validate_solver_result(result) -> dict:
     if not isinstance(overlap_ratio, (int, float)) or isinstance(overlap_ratio, bool):
         raise TypeError(f"'overlap_ratio'는 float여야 합니다 (실제 타입: {type(overlap_ratio).__name__})")
 
-    return {"paths": result["paths"], "cost": result["cost"], "overlap_ratio": overlap_ratio}
+    find_path_sec = result.get("find_path_sec")  # solver가 안 주면 None (선택 항목)
+    if find_path_sec is not None and (not isinstance(find_path_sec, (int, float)) or isinstance(find_path_sec, bool)):
+        raise TypeError(f"'find_path_sec'는 float여야 합니다 (실제 타입: {type(find_path_sec).__name__})")
+
+    return {"paths": result["paths"], "cost": result["cost"], "overlap_ratio": overlap_ratio, "find_path_sec": find_path_sec}
 
 
 def _compute_route_distance_km(graph, paths) -> float | None:
@@ -216,6 +221,7 @@ def _failed_row(solver: BasePathSolver, status: str, elapsed_sec: float, error: 
         "is_closed_loop": None,
         "spike_count": None,
         "edge_overlap_ratio": None,
+        "find_path_sec": None,
         "error": error,
     }
 

--- a/benchmarks/run_all_scenarios.py
+++ b/benchmarks/run_all_scenarios.py
@@ -1,34 +1,122 @@
 # run_all_scenarios.py
 
 import json
+import multiprocessing
 import time
 
 import pandas as pd
 
 from benchmarks.config import ROUTE_ENGINE_DATASET
-from benchmarks.benchmark import _load_default_graph, run_benchmark, SOLVER_REGISTRY
+from benchmarks.benchmark import (
+    _load_default_graph,
+    _failed_row,
+    _validate_solver_result,
+    _compute_route_distance_km,
+    _is_closed_loop,
+    _count_spikes,
+    _compute_edge_overlap_ratio,
+    RESULT_COLUMNS,
+    SOLVER_REGISTRY,
+)
 from src.route_engine.engines.path_utils import PathUtils
 from src.route_engine.engines.oneway_astar import precompute_landmarks
+from src.route_engine.scoring.scoring_engine import precompute_scoring_features
 
-ONEWAY_ALGOS   = ["beam-oneway", "grasp-oneway", "alns-oneway", "rcsp-oneway", "plateau", "astar-oneway", "bi-astar-oneway", "dijkstra-oneway"]
+ONEWAY_ALGOS   = ["astar-oneway", "dijkstra-oneway", "bi-astar-oneway", "beam-oneway", "grasp-oneway", "alns-oneway", "rcsp-oneway", "plateau"]
 CIRCULAR_ALGOS = ["beam-circular", "grasp-circular", "alns-circular", "rcsp-circular"]
 
-def main():
-    print("그래프 로딩 중...", flush=True)
-    t0 = time.perf_counter()
-    graph = _load_default_graph()
-    print(f"그래프 로딩 완료: {time.perf_counter() - t0:.1f}초, 노드 {graph.number_of_nodes()}개, 엣지 {graph.number_of_edges()}개", flush=True)
+_POOL_GRAPH = None  # 워커 프로세스 전역 — 워커당 1번만 채워짐(그래프 재전송 없음)
 
-    print("랜드마크 전처리 중...", flush=True)
-    t_lm = time.perf_counter()
-    precompute_landmarks(graph)
-    print(f"랜드마크 전처리 완료: {time.perf_counter() - t_lm:.1f}초", flush=True)
+
+def _pool_worker_init():
+    """워커 프로세스 시작 시 1회만 실행 — 그래프를 이 워커 메모리 안에 준비."""
+    global _POOL_GRAPH
+    _POOL_GRAPH = _load_default_graph()
+    precompute_landmarks(_POOL_GRAPH)
+    precompute_scoring_features(_POOL_GRAPH)
+
+
+def _pool_worker_task(solver_key: str, start_node, target_node, params: dict) -> dict:
+    """
+    태스크마다 실행. solver 인스턴스·그래프를 매번 안 받고,
+    solver_key로 SOLVER_REGISTRY에서 찾고 그래프는 워커 전역(_POOL_GRAPH)을 그대로 쓴다.
+    """
+    solver = SOLVER_REGISTRY[solver_key]
+    target_km = params.get("target_km")
+    time_budget_sec = params.get("time_budget_sec")
+
+    t0 = time.perf_counter()
+    try:
+        raw_result = solver.solve(_POOL_GRAPH, start_node, target_node, params)
+    except Exception as e:
+        return _failed_row(solver, "failed", time.perf_counter() - t0, repr(e), target_km)
+
+    elapsed = time.perf_counter() - t0
+
+    try:
+        result = _validate_solver_result(raw_result)
+    except Exception as e:
+        return _failed_row(solver, "failed", elapsed, str(e), target_km)
+
+    distance_km = _compute_route_distance_km(_POOL_GRAPH, result["paths"])
+    distance_deviation_km = (
+        round(abs(distance_km - target_km), 4) if distance_km is not None and target_km is not None else None
+    )
+    within_time_budget = elapsed <= time_budget_sec if time_budget_sec is not None else None
+
+    return {
+        "algorithm": solver.name,
+        "status": "ok",
+        "elapsed_sec": round(elapsed, 6),
+        "within_time_budget": within_time_budget,
+        "cost": result["cost"],
+        "overlap_ratio": result["overlap_ratio"],
+        "distance_km": distance_km,
+        "target_km": target_km,
+        "distance_deviation_km": distance_deviation_km,
+        "is_closed_loop": _is_closed_loop(result["paths"]),
+        "spike_count": _count_spikes(result["paths"]),
+        "edge_overlap_ratio": _compute_edge_overlap_ratio(result["paths"]),
+        "find_path_sec": result.get("find_path_sec"),
+        "error": "",
+    }
+
+
+def _run_scenario_with_pool(pool, algos, start_node, target_node, params, timeout_sec=30.0) -> pd.DataFrame:
+    """
+    이미 떠 있는 워커 풀에 알고리즘별 태스크를 제출하고 결과를 모은다.
+    타임아웃 시 해당 워커는 죽이지 않고 결과만 실패 처리한다(하드킬 포기 — 절충안).
+    """
+    async_results = {
+        key: pool.apply_async(_pool_worker_task, args=(key, start_node, target_node, params))
+        for key in algos
+    }
+    rows = []
+    for key, ar in async_results.items():
+        solver = SOLVER_REGISTRY[key]
+        try:
+            rows.append(ar.get(timeout=timeout_sec))
+        except multiprocessing.TimeoutError:
+            rows.append(_failed_row(
+                solver, "timeout", timeout_sec,
+                f"timeout after {timeout_sec}s (worker 강제종료 안 함 — 절충안)", params.get("target_km"),
+            ))
+    return pd.DataFrame(rows, columns=RESULT_COLUMNS)
+
+
+def main():
+    print("워커 풀 준비 중...", flush=True)
+    t0 = time.perf_counter()
+    pool = multiprocessing.get_context("spawn").Pool(processes=6, initializer=_pool_worker_init)
+    print(f"워커 풀 준비 완료: {time.perf_counter() - t0:.1f}초", flush=True)
+
+    graph = _load_default_graph()  # 부모 프로세스에선 노드 탐색(find_nearest_node)에만 사용
     utils = PathUtils(graph)
 
     with open(ROUTE_ENGINE_DATASET, encoding="utf-8") as f:
         dataset = json.load(f)
 
-    scenarios = dataset["scenarios"][:1]
+    scenarios = dataset["scenarios"]
     print(f"시나리오 {len(scenarios)}개 테스트 (oneway {sum(1 for s in scenarios if s['mode']=='oneway')}개, circular {sum(1 for s in scenarios if s['mode']=='circular')}개)\n", flush=True)
 
     all_rows = []
@@ -37,24 +125,25 @@ def main():
     for i, case in enumerate(scenarios, 1):
         mode = case["mode"]
         algos = ONEWAY_ALGOS if mode == "oneway" else CIRCULAR_ALGOS
-        solvers = [SOLVER_REGISTRY[key] for key in algos]
+        if not algos:
+            continue
 
         start_node = utils.find_nearest_node(case["start_lat"], case["start_lon"])
-        if mode == "oneway":
-            target_node = utils.find_nearest_node(case["end_lat"], case["end_lon"])
-        else:
-            target_node = start_node
+        target_node = utils.find_nearest_node(case["end_lat"], case["end_lon"]) if mode == "oneway" else start_node
 
         print(f"[{i}/{len(scenarios)}] {case['id']} ({mode}, profile={case['profile']}, target_km={case['target_km']}) 시작...", flush=True)
 
         params = {"target_km": case["target_km"], "profile": case["profile"]}
-        df = run_benchmark(solvers, graph, start_node, target_node, params, timeout_sec=30.0)
+        df = _run_scenario_with_pool(pool, algos, start_node, target_node, params, timeout_sec=30.0)
         df.insert(0, "scenario_id", case["id"])
         df.insert(1, "mode", mode)
         all_rows.append(df)
 
         ok_count = (df["status"] == "ok").sum()
         print(f"  -> {ok_count}/{len(df)} ok", flush=True)
+
+    pool.close()
+    pool.join()
 
     result_df = pd.concat(all_rows, ignore_index=True)
     out_path = "all_scenarios_results.csv"
@@ -69,14 +158,15 @@ def main():
         성공=("status", lambda s: (s == "ok").sum()),
         평균초=("elapsed_sec", "mean"),
         최대초=("elapsed_sec", "max"),
+        평균find_path초=("find_path_sec", "mean"),
         평균거리편차km=("distance_deviation_km", "mean"),
         평균우회도=("overlap_ratio", "mean"),
         평균자기중복=("edge_overlap_ratio", "mean"),
-    ).round(3)
+    ).round(4)
 
     print(summary.to_string())
-    
-    TARGET_AGNOSTIC_ALGOS = {"A*(oneway)", "Dijkstra(oneway)", "Bidirectional A*(oneway)"}  # target_km을 안 쓰는 순수 최단경로 solver
+
+    TARGET_AGNOSTIC_ALGOS = {"A*(oneway)", "Dijkstra(oneway)", "Bidirectional A*(oneway)"}
     hit = TARGET_AGNOSTIC_ALGOS & set(summary.index)
     if hit:
         print(
@@ -84,7 +174,6 @@ def main():
             "위 표의 평균거리편차km은 이 알고리즘들에겐 '목표 거리 달성도'가 아니라 출발-도착 간 "
             "자연 최단거리와 target_km의 우연한 차이일 뿐이므로, 우회 계열 solver와 나란히 비교하지 마세요."
         )
-
 
 
 if __name__ == "__main__":

--- a/benchmarks/solvers/astar_solver.py
+++ b/benchmarks/solvers/astar_solver.py
@@ -45,4 +45,4 @@ class OnewayAstarSolver(BasePathSolver):
 
         cost = engine.path_cost(nodes)
         overlap_ratio = base_shortest_path_overlap_ratio(engine, nodes, start_node, target_node)
-        return {"paths": [nodes], "cost": cost, "overlap_ratio": overlap_ratio}
+        return {"paths": [nodes], "cost": cost, "overlap_ratio": overlap_ratio, "find_path_sec": round(t3 - t2, 6)}

--- a/benchmarks/solvers/bi_astar_solver.py
+++ b/benchmarks/solvers/bi_astar_solver.py
@@ -45,4 +45,4 @@ class OnewayBidirectionalAstarSolver(BasePathSolver):
 
         cost = engine.path_cost(nodes)
         overlap_ratio = base_shortest_path_overlap_ratio(engine, nodes, start_node, target_node)
-        return {"paths": [nodes], "cost": cost, "overlap_ratio": overlap_ratio}
+        return {"paths": [nodes], "cost": cost, "overlap_ratio": overlap_ratio, "find_path_sec": round(t3 - t2, 6)}

--- a/benchmarks/solvers/dijkstra_solver.py
+++ b/benchmarks/solvers/dijkstra_solver.py
@@ -10,6 +10,7 @@ from benchmarks.solvers.base_solver import BasePathSolver
 from src.route_engine.engines.dijkstra import OnewayDijkstraEngine
 from src.route_engine.scoring.scoring_engine import compute_custom_score_lookup
 from src.schema.route_schema import OnewayRouteInput
+import time
 
 _DEFAULT_TARGET_KM = 3.0
 
@@ -38,10 +39,13 @@ class OnewayDijkstraSolver(BasePathSolver):
         engine._weight_fn    = scored["weight"]
         engine._score_lookup = scored["lookup"]
 
+        t0 = time.perf_counter()
         nodes = engine.find_path(start_node, target_node)
+        find_path_sec = time.perf_counter() - t0
+
         if not nodes or len(nodes) < 2:
             raise ValueError("경로 생성 실패: 유효한 편도 경로를 찾지 못했습니다 (NO_PATH)")
 
         cost = engine.path_cost(nodes)
         overlap_ratio = base_shortest_path_overlap_ratio(engine, nodes, start_node, target_node)
-        return {"paths": [nodes], "cost": cost, "overlap_ratio": overlap_ratio}
+        return {"paths": [nodes], "cost": cost, "overlap_ratio": overlap_ratio, "find_path_sec": round(find_path_sec, 6)}


### PR DESCRIPTION
## ☝️Issue Number
- resolve #335 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
1. `run_all_scenarios.py`를 워커 풀(`multiprocessing.Pool`) 기반으로 재작성 —
   워커를 한 번만 띄우고 그래프도 워커당 1회만 로드해 재사용한다. 타임아웃 시 해당
   워커를 강제종료하지 않는 절충안을 채택했다(표준 라이브러리만 사용, 신규 의존성 없음).
2. solver 결과에 `find_path_sec`(탐색 로직만의 소요 시간)을 추가해, 그래프 준비
   비용과 분리해서 볼 수 있게 했다.

- 50개 시나리오(oneway 8개 + circular 4개 알고리즘) 전체 소요시간: 2301초 → 226초
- 반복 실행 시 순위가 뒤바뀌던 현상 해소. `find_path_sec` 기준으로 A*(0.0073s) <
  Dijkstra(0.0086s) < 양방향 A*(0.0114s) 순으로 안정적으로 확인됨 — 다만 이 차이는
  전체 시간(0.2초대)에 비해 무시 가능한 수준이라 실사용 알고리즘 선택에는 영향 없음.