### PR TITLE
bugfix: 인증 실패 시 GET 응답에 status 반환 및 헤더 인증 확장

### DIFF
--- a/src/interfaces/api/login_router.py
+++ b/src/interfaces/api/login_router.py
@@ -1,8 +1,11 @@
 from fastapi import APIRouter, Body, Depends, Query, Request, Response
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from src.service.user.login_service import KakaoLoginService
 from src.interfaces.schema.login_schema import LoginUrlResponse, LoginResponse, MobileLoginRequest
 from src.interfaces.schema.auth_schema import AuthResponse, Status
 from src.interfaces.dependencies import get_kakao_login_service
+
+optional_bearer = HTTPBearer(auto_error=False)
 
 router = APIRouter(
     prefix="/api/login",
@@ -65,9 +68,10 @@ async def kakao_mobile_login(
 async def kakao_logout(
     request: Request,
     response: Response,
+    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
     service: KakaoLoginService = Depends(get_kakao_login_service)
 ):
-    access_token = request.cookies.get("access_token")
+    access_token = (credentials.credentials if credentials else None) or request.cookies.get("access_token")
     refresh_token = request.cookies.get("refresh_token")
 
     await service.logout(access_token, refresh_token)

--- a/src/interfaces/api/user_router.py
+++ b/src/interfaces/api/user_router.py
@@ -41,25 +41,21 @@ router = APIRouter(prefix="/api/user", tags=["user"])
 
 @router.get("/me", response_model=UserMeResponse)
 def get_me(
-    access_token: str = Cookie(None),
+    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
+    cookie_token: str = Cookie(None, alias="access_token"),
     service: UserService = Depends(get_user_service),
 ):
-    """
-    온보딩 설문 결과를 제출합니다.
-
-    input : 키워드 태그 목록, 선호 거리 선택지
-    output: 저장된 사용자 가중치 프로필
-    """
-    return service.get_me(access_token)
+    return service.get_me(_resolve_token(credentials, cookie_token))
 
 
 @router.patch("/me", response_model=UserUpdateResponse)
 def update_me(
     request: UserUpdateRequest,
-    access_token: str = Cookie(None),
+    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
+    cookie_token: str = Cookie(None, alias="access_token"),
     service: UserService = Depends(get_user_service),
 ):
-    return service.update_me(access_token, request.nickname)
+    return service.update_me(_resolve_token(credentials, cookie_token), request.nickname)
 
 
 @router.post("/survey", response_model=SurveyResponse)
@@ -77,7 +73,8 @@ def get_route_histories(
     limit: int = 20,
     offset: int = 0,
     is_favorite: Optional[bool] = None,
-    access_token: str = Cookie(None),
+    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
+    cookie_token: str = Cookie(None, alias="access_token"),
     auth_service: AuthService = Depends(get_auth_service),
 ):
     """
@@ -85,7 +82,9 @@ def get_route_histories(
     is_favorite을 지정하면 즐겨찾기 여부로 필터링합니다(예: true → 즐겨찾기만).
     """
     try:
-        status, provider, provider_id = auth_service.check_access_token(access_token)
+        status, provider, provider_id = auth_service.check_access_token(
+            _resolve_token(credentials, cookie_token)
+        )
         if status != Status.SUCCESS:
             logger.warning("경로 기록 조회 인증 실패: status=%s", status.value)
             raise HTTPException(status_code=401, detail=status.value)
@@ -112,12 +111,15 @@ def get_route_histories(
 @router.patch("/routes/{history_id}/favorite", response_model=RouteHistoryItem)
 def toggle_favorite(
     history_id: int,
-    access_token: str = Cookie(None),
+    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
+    cookie_token: str = Cookie(None, alias="access_token"),
     auth_service: AuthService = Depends(get_auth_service),
 ):
     """경로 기록의 즐겨찾기를 토글합니다."""
     try:
-        status, provider, provider_id = auth_service.check_access_token(access_token)
+        status, provider, provider_id = auth_service.check_access_token(
+            _resolve_token(credentials, cookie_token)
+        )
         if status != Status.SUCCESS:
             logger.warning("즐겨찾기 토글 인증 실패: status=%s, history_id=%s", status.value, history_id)
             raise HTTPException(status_code=401, detail=status.value)
@@ -143,14 +145,17 @@ def toggle_favorite(
 @router.get("/routes/{history_id}", response_model=RouteHistoryItem)
 def get_route_history(
     history_id: int,
-    access_token: str = Cookie(None),
+    credentials: HTTPAuthorizationCredentials = Depends(optional_bearer),
+    cookie_token: str = Cookie(None, alias="access_token"),
     auth_service: AuthService = Depends(get_auth_service),
 ):
     """
     특정 추천 경로 기록 상세를 조회합니다.
     """
     try:
-        status, provider, provider_id = auth_service.check_access_token(access_token)
+        status, provider, provider_id = auth_service.check_access_token(
+            _resolve_token(credentials, cookie_token)
+        )
         if status != Status.SUCCESS:
             logger.warning("경로 기록 상세 조회 인증 실패: status=%s, history_id=%s", status.value, history_id)
             raise HTTPException(status_code=401, detail=status.value)

--- a/src/interfaces/schema/survey_schema.py
+++ b/src/interfaces/schema/survey_schema.py
@@ -56,6 +56,7 @@ class SurveyResponse(BaseModel):
     
 class SurveyStatusResponse(BaseModel):
     """설문 완료 여부 및 저장된 가중치 조회 응답 스키마입니다."""
+    status: SurveyStatus
     survey_completed: bool
     default_target_km: Optional[float] = None
     weights_safety: Optional[float] = None

--- a/src/service/user/survey_service.py
+++ b/src/service/user/survey_service.py
@@ -137,17 +137,18 @@ class SurveyService:
         """사용자의 설문 완료 여부와 저장된 가중치를 반환합니다."""
         status, provider, provider_id = self.auth_service.check_access_token(access_token)
         if status != Status.SUCCESS:
-            return SurveyStatusResponse(survey_completed=False)
+            return SurveyStatusResponse(status=SurveyStatus(status.value), survey_completed=False)
 
         user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)
         if user is None:
-            return SurveyStatusResponse(survey_completed=False)
+            return SurveyStatusResponse(status=SurveyStatus.USER_NOT_FOUND, survey_completed=False)
 
         preference = UserPreferenceRepository.get_by_user_id(user.id)
         if preference is None or not preference.survey_completed:
-            return SurveyStatusResponse(survey_completed=False)
+            return SurveyStatusResponse(status=SurveyStatus.SUCCESS, survey_completed=False)
 
         return SurveyStatusResponse(
+            status=SurveyStatus.SUCCESS,
             survey_completed=True,
             default_target_km=preference.default_target_km,
             weights_safety=preference.weights_safety,


### PR DESCRIPTION
## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
GET /api/user/survey 가 인증 실패 시에도 survey_completed=false 만 반환해, 모바일 앱이 토큰 만료와 설문 미완료를 구분하지 못하고 온보딩 화면으로
분기하는 문제 수정.

- SurveyStatusResponse 에 status 필드 추가
- get_status() 에서 만료/무효/사용자없음/미완료 네 경우를 status로 구분
- user_router 5개 엔드포인트에 Authorization 헤더 인증 추가 (모바일 앱은 쿠키를 유지하지 않음)
- 로그아웃에 헤더 fallback 추가

