### PR TITLE
Refactor/339

### DIFF
--- a/docs/route_engine/README.md
+++ b/docs/route_engine/README.md
@@ -1,7 +1,7 @@
 # 경로 생성 엔진
 
 > 상태: Current
-> 기준일: 2026-07-30
+> 기준일: 2026-08-06
 > 관련 코드: `src/route_engine/`
 
 경로 생성 엔진은 외부 API나 챗봇 처리와 분리된 경로 계산 영역입니다.
@@ -18,6 +18,14 @@
 ## 계약 문서
 
 - [경로 그래프 계약](graph_contract.md)
+
+## Engine 반환 계약
+
+- `circular_beam`(`CircularBeamEngine`)·`oneway_beam`(`OnewayBeamEngine`)·`oneway_astar`(`OnewayAstarEngine`) 3개 엔진의 `run()`은 `List[WalkRouteResponse]`를 반환한다.
+- 같은 엔진들의 `find_path()`도 노드ID 경로 후보를 `list[list[int]]`로 감싸서 반환한다.
+- 현재는 항상 경로 1개만 생성해 리스트에 담아 반환한다. 여러 경로 후보를 동시에 생성하는 기능은 아직 구현하지 않았다.
+- `oneway_shortest` 모드의 실제 사용 엔진은 `dijkstra.py`(`OnewayDijkstraEngine`)에서 `oneway_astar.py`(`OnewayAstarEngine`)로 교체되었다. `OnewayDijkstraEngine`은 여전히 존재하지만 `route_service.py`에서는 더 이상 쓰지 않는다(벤치마크 등 다른 용도로만 남아있는지는 별도 확인 필요).
+- `route_service.get_route()`도 같은 계약(`List[WalkRouteResponse]`)으로 반환하며, 리스트의 첫 번째 요소만 사용해 POI 조회·이력 저장을 수행하고 리스트 전체를 그대로 반환한다.
 
 ## 영역 경계
 

--- a/src/route_engine/engines/__init__.py
+++ b/src/route_engine/engines/__init__.py
@@ -1,3 +1,4 @@
 from src.route_engine.engines.circular_beam  import CircularBeamEngine
 from src.route_engine.engines.dijkstra  import OnewayDijkstraEngine
+from src.route_engine.engines.oneway_astar   import OnewayAstarEngine
 from src.route_engine.engines.oneway_beam    import OnewayBeamEngine

--- a/src/route_engine/engines/circular_beam.py
+++ b/src/route_engine/engines/circular_beam.py
@@ -1,5 +1,5 @@
 import networkx as nx
-from typing import Optional
+from typing import Optional, List
 import logging
 
 from src.route_engine.engines.path_utils import PathUtils
@@ -34,7 +34,7 @@ class CircularBeamEngine:
         self.blocked_tags  = profile_config.blocked_tags
         self.scoring_mode  = profile_config.scoring_mode
 
-    def run(self) -> WalkRouteResponse:
+    def run(self) -> List[WalkRouteResponse]:
         """
         순환 경로를 생성합니다.
         """
@@ -56,26 +56,27 @@ class CircularBeamEngine:
         # 출발 노드가 없는 경우
         if start is None:
             logger.warning("출발 노드를 찾지 못했습니다.")
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.NO_NEAREST_START_NODE,
                 mode=self.mode,
                 coordinates=[],
                 total_km=0.0,
-            )
+            )]
 
-        # 경로 생성
-        nodes = self.find_path(start, self.inp.target_km or 3.0)
+        # 경로 생성 (경로 후보가 리스트에 감싸져서 반환됨)
+        candidates = self.find_path(start, self.inp.target_km or 3.0)
 
         # 경로가 없는 경우
-        if not nodes:
+        if not candidates:
             logger.warning("경로가 비어 있습니다.")
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.NO_PATH,
                 mode=self.mode,
                 coordinates=[],
                 total_km=0.0,
-            )
+            )]
 
+        nodes    = candidates[0]                            # 경로 1개만 사용
         pruned   = self.utils.prune_dead_ends(nodes)       # 왕복 가지 제거
         coords   = self.utils.extract_coordinates(pruned)  # [lat, lon] 좌표 목록
         total_m  = self.utils.calc_distance(pruned)        # 총 이동 거리(미터)
@@ -83,14 +84,14 @@ class CircularBeamEngine:
 
         logger.info("경로 생성 완료: total_km=%.2f (target=%.2f), 노드=%d개", total_km, self.inp.target_km or 3.0, len(nodes))
 
-        return WalkRouteResponse(
+        return [WalkRouteResponse(
             status          = WalkRouteStatus.SUCCESS if coords else WalkRouteStatus.NO_PATH,
             mode            = self.mode,
             coordinates     = coords,
             total_km        = total_km,
-        )
+        )]
 
-    def find_path(self, start_node: int, target_km: float = 3.0) -> list[int]:
+    def find_path(self, start_node: int, target_km: float = 3.0) -> list[list[int]]:
         """
         beam search 기반 순환 경로를 생성합니다.
         """
@@ -103,7 +104,7 @@ class CircularBeamEngine:
         pool = self._build_pool(finished, beams)
         if not pool:
             logger.warning("beam search 후보가 비어 출발 노드만 반환합니다.")
-            return [start_node]
+            return [[start_node]]
 
         # 2단계: 반환점 → 출발지 + 가장 좋은 완성 경로 1개 채택
         best_path, best_key = None, None
@@ -118,11 +119,11 @@ class CircularBeamEngine:
         # 모든 후보가 복귀에 실패한 경우의 방어 코드
         if best_path is None:
             logger.warning("복귀 가능한 후보가 없어 첫 후보의 바깥 경로를 반환합니다.")
-            return pool[0][1]
+            return [pool[0][1]]
 
         logger.info("beam search 경로 선택: 노드=%d개, 거리초과=%.0fm, 품질밀도=%.3f",
                     len(best_path), best_key[0], best_key[1])
-        return best_path
+        return [best_path]
 
     def _find_start_to_waypoint(self, start_node: int, target_m: float) -> tuple:
         """

--- a/src/route_engine/engines/oneway_astar.py
+++ b/src/route_engine/engines/oneway_astar.py
@@ -1,5 +1,5 @@
 import networkx as nx
-from typing import Optional
+from typing import Optional, List
 import logging
 
 from src.route_engine.engines.path_utils import PathUtils
@@ -34,7 +34,7 @@ class OnewayAstarEngine:
         self._score_lookup: dict = {}
         self._min_ratio    = 1.0
 
-    def run(self) -> WalkRouteResponse:
+    def run(self) -> List[WalkRouteResponse]:
         """
         A* 최단 경로를 생성합니다.
         """
@@ -55,50 +55,52 @@ class OnewayAstarEngine:
 
         if start is None:
             logger.warning("출발 노드를 찾지 못했습니다.")
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.NO_NEAREST_START_NODE,
                 mode=self.mode, coordinates=[], total_km=0.0,
-            )
+            )]
 
         if end is None:
             logger.warning("도착 노드를 찾지 못했습니다.")
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.NO_NEAREST_END_NODE,
                 mode=self.mode, coordinates=[], total_km=0.0,
-            )
+            )]
 
-        nodes = self.find_path(start, end)
+        # 경로 생성 (경로 후보가 리스트에 감싸져서 반환됨)
+        candidates = self.find_path(start, end)
 
-        if not nodes:
+        if not candidates:
             logger.warning("경로가 비어 있습니다.")
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.NO_PATH,
                 mode=self.mode, coordinates=[], total_km=0.0,
-            )
+            )]
 
+        nodes     = candidates[0]                          # 경로 1개만 사용
         coords    = self.utils.extract_coordinates(nodes)
         total_m   = self.utils.calc_distance(nodes)
         total_km = round(total_m / 1000, 2)
 
         logger.info(f"total_km: {total_km}")
 
-        return WalkRouteResponse(
+        return [WalkRouteResponse(
             status          = WalkRouteStatus.SUCCESS if coords else WalkRouteStatus.NO_PATH,
             mode            = self.mode,
             coordinates     = coords,
             total_km        = total_km,
-        )
+        )]
 
-    def find_path(self, start: int, end: int) -> list[int]:
+    def find_path(self, start: int, end: int) -> list[list[int]]:
         """
         A* 알고리즘으로 최단 경로 노드 목록을 반환합니다.
         """
         try:
-            return nx.astar_path(
+            return [nx.astar_path(
                 self.G, start, end,
                 heuristic=self._heuristic,
                 weight=self._weight_fn,
-            )
+            )]
         except nx.NetworkXNoPath:
             logger.warning("출발-도착 노드 사이에 연결된 경로가 없습니다")
             return []

--- a/src/route_engine/engines/oneway_beam.py
+++ b/src/route_engine/engines/oneway_beam.py
@@ -1,5 +1,5 @@
 import networkx as nx
-from typing import Optional
+from typing import Optional, List
 import logging
 
 from src.route_engine.engines.path_utils import PathUtils
@@ -34,7 +34,7 @@ class OnewayBeamEngine:
         self.blocked_tags  = profile_config.blocked_tags
         self.scoring_mode  = profile_config.scoring_mode
 
-    def run(self) -> WalkRouteResponse:
+    def run(self) -> List[WalkRouteResponse]:
         """
         우회 편도 경로를 생성합니다.
         """
@@ -54,36 +54,37 @@ class OnewayBeamEngine:
         # 출발 노드가 없는 경우
         if start is None:
             logger.warning("출발 노드를 찾지 못했습니다.")
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.NO_NEAREST_START_NODE,
                 mode=self.mode,
                 coordinates=[],
                 total_km=0.0,
-            )
+            )]
 
         # 도착 노드가 없는 경우
         if end is None:
             logger.warning("도착 노드를 찾지 못했습니다.")
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.NO_NEAREST_END_NODE,
                 mode=self.mode,
                 coordinates=[],
                 total_km=0.0,
-            )
+            )]
 
-        # 경로 생성
-        nodes = self.find_path(start, end, self.inp.target_km or 3.0)
+        # 경로 생성 (경로 후보가 리스트에 감싸져서 반환됨)
+        candidates = self.find_path(start, end, self.inp.target_km or 3.0)
 
         # 경로가 없는 경우
-        if not nodes:
+        if not candidates:
             logger.warning("경로가 비어 있습니다.")
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.NO_PATH,
                 mode=self.mode,
                 coordinates=[],
                 total_km=0.0,
-            )
+            )]
 
+        nodes    = candidates[0]                            # 경로 1개만 사용
         pruned   = self.utils.prune_dead_ends(nodes)       # 왕복 가지 제거
         coords   = self.utils.extract_coordinates(pruned)  # [lat, lon] 좌표 목록
         total_m  = self.utils.calc_distance(pruned)        # 총 이동 거리(m)
@@ -91,14 +92,14 @@ class OnewayBeamEngine:
 
         logger.info(f"total_km: {total_km}")
 
-        return WalkRouteResponse(
+        return [WalkRouteResponse(
             status          = WalkRouteStatus.SUCCESS if coords else WalkRouteStatus.NO_PATH,
             mode            = self.mode,
             coordinates     = coords,
             total_km        = total_km,
-        )
+        )]
 
-    def find_path(self, start: int, end: int, target_km: float = 3.0) -> list[int]:
+    def find_path(self, start: int, end: int, target_km: float = 3.0) -> list[list[int]]:
         """
         beam search 기반 우회 편도 경로를 생성합니다.
         """
@@ -123,7 +124,7 @@ class OnewayBeamEngine:
         pool = self._build_pool(finished, beams)
         if not pool:
             logger.warning("beam search 후보가 비어 최단 경로로 대체합니다.")
-            return base_shortest
+            return [base_shortest]
 
         # 2단계: 중간지점 → 도착지 + 가장 좋은 완성 경로 1개 채택
         best_path, best_key = None, None
@@ -140,11 +141,11 @@ class OnewayBeamEngine:
         # 모든 후보가 도착 연결에 실패한 경우의 방어 코드
         if best_path is None:
             logger.warning("도착 연결 가능한 후보가 없어 최단 경로로 대체합니다.")
-            return base_shortest
+            return [base_shortest]
 
         logger.info("beam search 편도 경로 선택: 노드=%d개, 거리초과=%.0fm, 우회도=%.3f, 품질밀도=%.3f",
                     len(best_path), best_key[0], best_key[1], best_key[2])
-        return best_path
+        return [best_path]
 
 
     def _overlap_ratio(self, path: list[int], base_edges: set) -> float:

--- a/src/schema/prewalk_schema.py
+++ b/src/schema/prewalk_schema.py
@@ -77,7 +77,7 @@ class State(BaseModel):
     origin_candidate: Optional[List[Location]] = None
     destination_candidate: Optional[List[Location]] = None
 
-    route_result: Optional[WalkRouteResponse] = None
+    route_result: Optional[List[WalkRouteResponse]] = None
     is_complete: bool = False
     awaiting_confirmation: bool = False
     user_prompt: str  = ""

--- a/src/service/route/route_service.py
+++ b/src/service/route/route_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Optional, List
 
 import networkx as nx
 
@@ -16,7 +16,7 @@ from src.repository.user.user_repository import UserRepository
 from src.repository.layer.route_poi_repository import RoutePoiRepository
 from src.route_engine.engines import (
     CircularBeamEngine,
-    OnewayDijkstraEngine,
+    OnewayAstarEngine,
     OnewayBeamEngine,
 )
 from src.route_engine.engines.path_utils import PathUtils
@@ -34,7 +34,7 @@ class RouteService:
 
         self.base_engines: dict = {
             WalkMode.CIRCULAR_RANDOM: CircularBeamEngine,
-            WalkMode.ONEWAY_SHORTEST: OnewayDijkstraEngine,
+            WalkMode.ONEWAY_SHORTEST: OnewayAstarEngine,
             WalkMode.ONEWAY_RANDOM: OnewayBeamEngine,
         }
 
@@ -47,7 +47,7 @@ class RouteService:
         mode: WalkMode = WalkMode.CIRCULAR_RANDOM,
         custom_weights: Optional[Weights] = None,
         profile: Optional[ScoringProfile] = None,
-    ) -> WalkRouteResponse:
+    ) -> List[WalkRouteResponse]:
         """
         context에 적합한 경로 생성 엔진을 호출합니다.
         mode는 경로 생성 방식(circular_random/oneway_shortest/oneway_random)을,
@@ -66,56 +66,57 @@ class RouteService:
         auth_status, provider, provider_id = self.auth_service.check_access_token(access_token)
         if auth_status != Status.SUCCESS:
             logger.warning("walk route auth failed: mode=%s status=%s", mode, auth_status.value)
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus(auth_status.value),
                 mode=mode,
                 coordinates=[],
                 total_km=0.0,
-            )
+            )]
 
         if mode not in self.base_engines:
             logger.warning("walk route unknown mode: mode=%s", mode)
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.UNKNOWN_ERROR,
                 mode=mode,
                 coordinates=[],
                 total_km=0.0,
-            )
+            )]
 
         utils = PathUtils(self.G)
         if utils.find_nearest_node_with_expansion(origin.lat, origin.lon) is None:
             logger.warning("walk route no nearest start node: mode=%s", mode)
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.NO_NEAREST_START_NODE,
                 mode=mode,
                 coordinates=[],
                 total_km=0.0,
-            )
+            )]
 
         if mode != WalkMode.CIRCULAR_RANDOM and destination is not None:
             if utils.find_nearest_node_with_expansion(destination.lat, destination.lon) is None:
                 logger.warning("walk route no nearest end node: mode=%s", mode)
-                return WalkRouteResponse(
+                return [WalkRouteResponse(
                     status=WalkRouteStatus.NO_NEAREST_END_NODE,
                     mode=mode,
                     coordinates=[],
                     total_km=0.0,
-                )
+                )]
 
         try:
             engine = self._build_engine(mode, origin, destination, target_km, custom_weights, profile)
         except ValueError:
             logger.warning("walk route invalid destination: mode=%s", mode)
-            return WalkRouteResponse(
+            return [WalkRouteResponse(
                 status=WalkRouteStatus.INVALID_DESTINATION,
                 mode=mode,
                 coordinates=[],
                 total_km=0.0,
-            )
+            )]
 
         logger.info("walk route engine selected: mode=%s engine=%s", mode, type(engine).__name__)
 
-        result = engine.run()
+        results = engine.run()
+        result  = results[0]  # 경로 후보는 1개만 사용
         logger.info("walk route result: mode=%s status=%s total_km=%s", mode, result.status.value, result.total_km)
 
         if result.status == WalkRouteStatus.SUCCESS:
@@ -146,7 +147,7 @@ class RouteService:
             except Exception:
                 logger.exception("walk route history save failed: mode=%s", mode)
 
-        return result
+        return results
 
     def _build_engine(
         self,

--- a/tests/unit/test_routue_service.py
+++ b/tests/unit/test_routue_service.py
@@ -91,14 +91,14 @@ class TestAuthFailure:
 
         result = service.get_route(ACCESS_TOKEN, origin=ORIGIN, mode=WalkMode.CIRCULAR_RANDOM)
 
-        assert result.status == WalkRouteStatus.ACCESS_EXPIRED_TOKEN
+        assert result[0].status == WalkRouteStatus.ACCESS_EXPIRED_TOKEN
 
     def test_토큰이_유효하지_않으면_invalid_token_status를_반환한다(self, service, auth_service):
         auth_service.check_access_token.return_value = (Status.INVALID_TOKEN, None, None)
 
         result = service.get_route(ACCESS_TOKEN, origin=ORIGIN, mode=WalkMode.CIRCULAR_RANDOM)
 
-        assert result.status == WalkRouteStatus.INVALID_TOKEN
+        assert result[0].status == WalkRouteStatus.INVALID_TOKEN
 
 
 class TestUnknownMode:
@@ -122,7 +122,7 @@ class TestOnewayWithoutDestination:
     ):
         result = service.get_route(ACCESS_TOKEN, origin=ORIGIN, mode=mode)
 
-        assert result.status == WalkRouteStatus.INVALID_DESTINATION
+        assert result[0].status == WalkRouteStatus.INVALID_DESTINATION
 
 
 class TestModeRouting:
@@ -136,7 +136,7 @@ class TestModeRouting:
     )
     def test_모드에_맞는_엔진이_호출된다(self, service, patched_nodes, mode, destination):
         mock_engine_instance = MagicMock()
-        mock_engine_instance.run.return_value = SUCCESS_RESPONSE.model_copy(update={"mode": mode})
+        mock_engine_instance.run.return_value = [SUCCESS_RESPONSE.model_copy(update={"mode": mode})]
         MockEngineClass = MagicMock(return_value=mock_engine_instance)
 
         service.base_engines[mode] = MockEngineClass
@@ -152,7 +152,7 @@ class TestModeRouting:
 
     def test_엔진의_run_결과가_그대로_반환된다(self, service, patched_nodes):
         mock_engine_instance = MagicMock()
-        mock_engine_instance.run.return_value = SUCCESS_RESPONSE
+        mock_engine_instance.run.return_value = [SUCCESS_RESPONSE]
         MockEngineClass = MagicMock(return_value=mock_engine_instance)
 
         service.base_engines[WalkMode.CIRCULAR_RANDOM] = MockEngineClass
@@ -163,12 +163,12 @@ class TestModeRouting:
             mode=WalkMode.CIRCULAR_RANDOM,
         )
 
-        assert result.status == WalkRouteStatus.SUCCESS
-        assert result.total_km == 1.5
+        assert result[0].status == WalkRouteStatus.SUCCESS
+        assert result[0].total_km == 1.5
 
     def test_성공_경로에는_주변_POI를_붙인다(self, service, patched_nodes):
         mock_engine_instance = MagicMock()
-        mock_engine_instance.run.return_value = SUCCESS_RESPONSE.model_copy()
+        mock_engine_instance.run.return_value = [SUCCESS_RESPONSE.model_copy()]
         service.base_engines[WalkMode.CIRCULAR_RANDOM] = MagicMock(
             return_value=mock_engine_instance
         )
@@ -193,11 +193,11 @@ class TestModeRouting:
             )
 
         find_pois.assert_called_once_with(SUCCESS_RESPONSE.coordinates)
-        assert result.nearby_pois[0].category == "toilet"
+        assert result[0].nearby_pois[0].category == "toilet"
 
     def test_엔진이_실패_status를_반환하면_그대로_전달된다(self, service, patched_nodes):
         mock_engine_instance = MagicMock()
-        mock_engine_instance.run.return_value = FAILED_RESPONSE
+        mock_engine_instance.run.return_value = [FAILED_RESPONSE]
         MockEngineClass = MagicMock(return_value=mock_engine_instance)
 
         service.base_engines[WalkMode.CIRCULAR_RANDOM] = MockEngineClass
@@ -208,7 +208,7 @@ class TestModeRouting:
             mode=WalkMode.CIRCULAR_RANDOM,
         )
 
-        assert result.status == WalkRouteStatus.NO_PATH
+        assert result[0].status == WalkRouteStatus.NO_PATH
 
 
 def _chat_state(themes=None, profile=None):


### PR DESCRIPTION
## ☝️Issue Number
- resolve #339 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 경로 생성 엔진(`circular_beam`, `oneway_beam`, `oneway_astar`)의 `find_path()`/`run()` 반환 타입을 단일 경로에서 "경로 후보 리스트"(`list[list[int]]` / `List[WalkRouteResponse]`)로 통일. 아직 후보를 여러 개 생성하지는 않고, 향후 다중 후보 확장을 위해 반환 타입만 리스트로 감쌈.
- `oneway_shortest` 모드의 실사용 엔진을 `OnewayDijkstraEngine`에서 `OnewayAstarEngine`으로 교체(랜드마크 휴리스틱 A*), 세 모드(`circular_random`/`oneway_shortest`/`oneway_random`) 모두 동일한 리스트 반환 계약을 따르도록 정리.
- `route_service.get_route()`가 `List[WalkRouteResponse]`를 반환하도록 수정. 내부적으로는 후보 중 1개만 사용해 POI 조회·이력 저장을 수행.
- 위 변경에 맞춰 `tests/unit/test_routue_service.py` 단위 테스트 갱신, `docs/route_engine/README.md`에 Engine 반환 계약 문서화.