### PR TITLE
Feat/341

### DIFF
--- a/docs/route_engine/README.md
+++ b/docs/route_engine/README.md
@@ -27,6 +27,16 @@
 - `oneway_shortest` 모드의 실제 사용 엔진은 `dijkstra.py`(`OnewayDijkstraEngine`)에서 `oneway_astar.py`(`OnewayAstarEngine`)로 교체되었다. `OnewayDijkstraEngine`은 여전히 존재하지만 `route_service.py`에서는 더 이상 쓰지 않는다(벤치마크 등 다른 용도로만 남아있는지는 별도 확인 필요).
 - `route_service.get_route()`도 같은 계약(`List[WalkRouteResponse]`)으로 반환하며, 리스트의 첫 번째 요소만 사용해 POI 조회·이력 저장을 수행하고 리스트 전체를 그대로 반환한다.
 
+## Waypoint(경유지) 조합 엔진
+
+- `waypoint.py`(`WaypointComposerEngine`)는 출발지 → 경유지들 → 목적지를 구간(leg)별로 나눠, 각 leg에 지정된 모드의 기존 편도 엔진(`OnewayAstarEngine`/`OnewayBeamEngine`)을 순차 호출해 하나의 경로로 이어 붙인다. 새 탐색 알고리즘은 추가하지 않고 기존 엔진을 조합만 한다.
+- 입력은 `WaypointRouteInput`(`src/schema/route_schema.py`)이며 `waypoints`(경유지 좌표 리스트), `leg_modes`(leg별 모드), `leg_target_km`(leg별 목표 거리, `oneway_random` leg만 필수)로 구성된다. `len(leg_modes) == len(waypoints) + 1`이어야 한다.
+- `leg_modes`/`leg_target_km`은 `WalkMode`/`Coordinate`를 그대로 쓰지 않고 `route_schema.py` 안에 로컬로 정의한 `WaypointLegMode`(`Literal["oneway_shortest", "oneway_random"]`)와 `WaypointCoordinate`를 쓴다. `route_schema.py -> walk_schema.py -> route_engine.profiles -> route_schema.py(Weights)`로 이어지는 기존 순환 임포트 때문에 `walk_schema.py`의 타입을 직접 가져올 수 없어서다.
+- `WaypointComposerEngine.__init__`은 `G.copy()`를 한 번만 만들어 모든 leg 엔진 생성자에 공유한다. 인접 leg의 경계 좌표는 동일한 `(lat, lon)` 값을 그대로 재사용해 노드 스냅 불일치를 방지한다.
+- leg가 실패하면(그리고 아직 `oneway_shortest`로 시도하지 않았다면) `OnewayAstarEngine`으로 그 leg만 재시도한다(다른 엔진들의 `base_shortest` 대체와 같은 패턴). 그 재시도까지 실패해야 해당 leg에서 중단한다.
+- 결과 상태(`_stitch`)는 모든 leg 성공 시 `SUCCESS`, 일부만 성공 시 `PARTIAL_ROUTE`(성공한 구간까지만 좌표·거리 반환), 첫 leg부터(재시도 포함) 실패하면 그 leg의 실패 status를 그대로 사용한다. `mode`는 이 조합 전용으로 추가한 `WalkMode.WAYPOINT`를 쓴다.
+- 아직 `route_service.py`/`walk_router.py`(API)와는 연동하지 않았다 — `route_engine` 안에서만 호출 가능하다. 챗봇 연동을 포함한 leg별 `profile`/`custom_weights` 지정은 아직 지원하지 않고, 현재는 `WaypointComposerEngine` 생성자의 공통 `custom_weights`/`profile` 값을 모든 leg에 동일하게 적용한다.
+
 ## 영역 경계
 
 - 외부 API와 LLM을 직접 호출하지 않습니다.

--- a/src/interfaces/schema/walk_schema.py
+++ b/src/interfaces/schema/walk_schema.py
@@ -46,6 +46,7 @@ class WalkMode(str, Enum):
     CIRCULAR_RANDOM = "circular_random"
     ONEWAY_SHORTEST = "oneway_shortest"
     ONEWAY_RANDOM = "oneway_random"
+    WAYPOINT = "waypoint"
 
 
 class WalkRouteStatus(str, Enum):

--- a/src/route_engine/engines/__init__.py
+++ b/src/route_engine/engines/__init__.py
@@ -1,4 +1,4 @@
 from src.route_engine.engines.circular_beam  import CircularBeamEngine
-from src.route_engine.engines.dijkstra  import OnewayDijkstraEngine
 from src.route_engine.engines.oneway_astar   import OnewayAstarEngine
 from src.route_engine.engines.oneway_beam    import OnewayBeamEngine
+from src.route_engine.engines.waypoint       import WaypointComposerEngine

--- a/src/route_engine/engines/waypoint.py
+++ b/src/route_engine/engines/waypoint.py
@@ -1,0 +1,129 @@
+import logging
+from typing import List, Optional
+
+import networkx as nx
+
+from src.interfaces.schema.walk_schema import (
+    WalkMode,
+    WalkRouteResponse,
+    WalkRouteStatus,
+)
+from src.route_engine.engines.oneway_astar import OnewayAstarEngine
+from src.route_engine.engines.oneway_beam import OnewayBeamEngine
+from src.route_engine.profiles import ScoringProfile
+from src.schema.route_schema import OnewayRouteInput, WaypointRouteInput, Weights
+
+logger = logging.getLogger(__name__)
+
+# leg_modes 값(WaypointRouteInput.WaypointLegMode)별로 재사용할 기존 편도 엔진
+_LEG_ENGINES = {
+    "oneway_shortest": OnewayAstarEngine,
+    "oneway_random": OnewayBeamEngine,
+}
+
+
+class WaypointComposerEngine:
+    """
+    출발지 -> 경유지들 -> 목적지를 구간(leg)별로 나눠, 각 leg에 지정된 모드의
+    기존 편도 엔진(OnewayAstarEngine/OnewayBeamEngine)을 순차 호출해 하나의 경로로 이어 붙인다.
+    새 탐색 알고리즘을 추가하지 않고 기존 엔진을 조합만 한다.
+    """
+
+    def __init__(
+        self,
+        inp: WaypointRouteInput,
+        G: nx.Graph,
+        custom_weights: Optional[Weights] = None,
+        profile: Optional[ScoringProfile] = None,
+    ):
+        self.inp            = inp
+        self.G               = G.copy()  # 모든 leg가 공유하는 원본 보호용 복사본 1개
+        self.custom_weights  = custom_weights
+        self.profile         = profile
+        self.mode            = WalkMode.WAYPOINT
+
+    def run(self) -> List[WalkRouteResponse]:
+        """
+        경유지 반영 경로를 leg별로 생성해 하나로 이어 붙입니다.
+        """
+        logger.info(
+            "경유지 반영 경로 생성 엔진을 시작합니다: legs=%d, leg_modes=%s",
+            len(self.inp.leg_modes), self.inp.leg_modes,
+        )
+
+        # stops = [(start_lat, start_lon), (wp1.lat, wp1.lon), (wp2.lat, wp2.lon), (end_lat, end_lon)]
+        stops = [
+            (self.inp.start_lat, self.inp.start_lon),          # 출발지
+            *[(wp.lat, wp.lon) for wp in self.inp.waypoints],  # 경유지  cf. *(unpacking)은 중첩 리스트를 풀어서 넣으라는 뜻
+            (self.inp.end_lat, self.inp.end_lon),              # 목적지
+        ]
+
+        leg_results: List[WalkRouteResponse] = []
+        for i, mode in enumerate(self.inp.leg_modes):
+            start_lat, start_lon = stops[i]
+            end_lat, end_lon     = stops[i + 1]
+            leg_inp = OnewayRouteInput(
+                start_lat=start_lat,
+                start_lon=start_lon,
+                end_lat=end_lat,
+                end_lon=end_lon,
+                target_km=self.inp.leg_target_km[i],
+            )
+            engine = _LEG_ENGINES[mode](
+                leg_inp, self.G, custom_weights=self.custom_weights, profile=self.profile,
+            )
+            result = engine.run()[0]  # leg 엔진도 후보 리스트를 반환하므로 1개만 사용
+
+            # 다른 엔진들의 base_shortest 대체와 같은 패턴: 실패하면 최단 경로로 재시도
+            if result.status != WalkRouteStatus.SUCCESS and mode != "oneway_shortest":
+                logger.warning("leg %d(%s)에서 실패해 최단 경로로 대체합니다: status=%s",
+                               i + 1, mode, result.status.value)
+                fallback = OnewayAstarEngine(
+                    leg_inp, self.G, custom_weights=self.custom_weights, profile=self.profile,
+                )
+                result = fallback.run()[0]
+
+            leg_results.append(result)
+
+            logger.info("leg %d/%d 결과: mode=%s status=%s", i + 1, len(self.inp.leg_modes), mode, result.status.value)
+
+            if result.status != WalkRouteStatus.SUCCESS:
+                logger.warning("leg %d에서 최단 경로 대체도 실패해 이후 leg를 생략합니다: status=%s", i + 1, result.status.value)
+                break
+
+        return [self._stitch(leg_results, len(self.inp.leg_modes))]
+
+    def _stitch(self, leg_results: List[WalkRouteResponse], total_legs: int) -> WalkRouteResponse:
+        """
+        성공한 leg들의 좌표·거리를 이어 붙이고, 전체 상태를 판정합니다.
+        - 모든 leg 성공: SUCCESS
+        - 일부 leg만 성공: PARTIAL_ROUTE (성공한 구간까지만 반환)
+        - 첫 leg부터 실패: 그 leg의 실패 status를 그대로 사용
+        """
+        successful = [r for r in leg_results if r.status == WalkRouteStatus.SUCCESS]
+
+        coordinates: list = []
+        total_m = 0.0
+        for i, leg in enumerate(successful):
+            # 인접 leg의 경계 좌표는 동일한 지점이므로 두 번째 leg부터 첫 좌표를 건너뜀
+            coords = leg.coordinates[1:] if i > 0 else leg.coordinates
+            coordinates.extend(coords)
+            total_m += leg.total_km * 1000
+
+        if len(successful) == total_legs:
+            status = WalkRouteStatus.SUCCESS
+        elif successful:
+            status = WalkRouteStatus.PARTIAL_ROUTE
+        else:
+            status = leg_results[0].status
+
+        total_km = round(total_m / 1000, 2)
+        logger.info("경유지 경로 완성: status=%s, 성공 leg=%d/%d, total_km=%.2f",
+                    status.value, len(successful), total_legs, total_km)
+
+        return WalkRouteResponse(
+            status      = status,
+            mode        = self.mode,
+            coordinates = coordinates,
+            total_km    = total_km,
+        )

--- a/src/schema/route_schema.py
+++ b/src/schema/route_schema.py
@@ -1,5 +1,5 @@
-from typing import Optional
-from pydantic import BaseModel, Field
+from typing import Literal, Optional
+from pydantic import BaseModel, Field, model_validator
 
 class CircularRouteInput(BaseModel):
     start_lat: float
@@ -13,6 +13,47 @@ class OnewayRouteInput(BaseModel):
     end_lat:   float
     end_lon:   float
     target_km: Optional[float] = None
+
+
+# route_schema.py -> walk_schema.py -> route_engine.profiles -> route_schema.py(Weights)로
+# 이어지는 기존 순환 임포트가 있어, walk_schema의 Coordinate/WalkMode를 그대로 가져다 쓸 수 없다.
+# 그래서 좌표·모드 값을 이 파일 안에서 최소한으로 다시 정의한다.
+WaypointLegMode = Literal["oneway_shortest", "oneway_random"]
+
+
+class WaypointCoordinate(BaseModel):
+    lat: float
+    lon: float
+
+
+class WaypointRouteInput(BaseModel):
+    start_lat: float
+    start_lon: float
+    end_lat:   float
+    end_lon:   float
+    waypoints: list[WaypointCoordinate] = Field(default_factory=list)
+    leg_modes: list[WaypointLegMode]
+    leg_target_km: list[Optional[float]]
+
+    @model_validator(mode="after")
+    def check_leg_counts(self) -> "WaypointRouteInput":
+        expected_legs = len(self.waypoints) + 1
+        if len(self.leg_modes) != expected_legs:
+            raise ValueError(
+                f"leg_modes 길이({len(self.leg_modes)})는 waypoints+1({expected_legs})과 같아야 합니다"
+            )
+        if len(self.leg_target_km) != expected_legs:
+            raise ValueError(
+                f"leg_target_km 길이({len(self.leg_target_km)})는 waypoints+1({expected_legs})과 같아야 합니다"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def check_leg_target_km_for_random(self) -> "WaypointRouteInput":
+        for mode, target_km in zip(self.leg_modes, self.leg_target_km):
+            if mode == "oneway_random" and target_km is None:
+                raise ValueError("oneway_random leg는 leg_target_km 값이 필요합니다")
+        return self
 
 
 class Weights(BaseModel):


### PR DESCRIPTION
## ☝️Issue Number
- resolve #341 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 출발지 → 경유지(들) → 목적지를 반영한 경로 생성 로직을 `route_engine`에 추가. 새 탐색 알고리즘을 만들지 않고, 이미 구현된 편도 엔진(`OnewayAstarEngine`/`OnewayBeamEngine`)을 구간(leg)별로 순차 호출해 하나의 경로로 이어 붙이는 방식.
- `WalkMode.WAYPOINT` 신설, `WaypointRouteInput`(`waypoints`, leg별 `leg_modes`/`leg_target_km`) 스키마 추가. 구간마다 모드(편도 최단/편도 우회)가 달라질 수 있도록 leg 단위로 입력받음.
- `WaypointComposerEngine` 구현: 그래프는 `G.copy()` 한 번만 만들어 모든 leg가 공유, 인접 leg의 경계 좌표를 재사용해 노드 스냅 불일치를 방지, 좌표 이어붙이기 시 경계 중복 좌표 제거.
- leg가 실패하면 바로 포기하지 않고 기존 엔진들의 `base_shortest` 대체 패턴처럼 `OnewayAstarEngine`(최단 경로)으로 그 leg만 재시도. 그마저 실패해야 중단.
- 전체 성공은 `SUCCESS`, 일부 leg만 성공하면 `PARTIAL_ROUTE`(성공 구간까지만 반환), 첫 leg부터 실패하면 해당 leg의 실패 status를 그대로 전달.
- 단위 테스트(`tests/unit/test_waypoint_engine.py`, 11개)와 `docs/route_engine/README.md` 계약 문서 추가.
