### PR TITLE
[Refactor] 출발지 -> 경유지 -> 목적지 경로 생성 중 중복 방지 로직 추가

### DIFF
--- a/docs/route_engine/README.md
+++ b/docs/route_engine/README.md
@@ -37,6 +37,15 @@
 - 결과 상태(`_stitch`)는 모든 leg 성공 시 `SUCCESS`, 일부만 성공 시 `PARTIAL_ROUTE`(성공한 구간까지만 좌표·거리 반환), 첫 leg부터(재시도 포함) 실패하면 그 leg의 실패 status를 그대로 사용한다. `mode`는 이 조합 전용으로 추가한 `WalkMode.WAYPOINT`를 쓴다.
 - 아직 `route_service.py`/`walk_router.py`(API)와는 연동하지 않았다 — `route_engine` 안에서만 호출 가능하다. 챗봇 연동을 포함한 leg별 `profile`/`custom_weights` 지정은 아직 지원하지 않고, 현재는 `WaypointComposerEngine` 생성자의 공통 `custom_weights`/`profile` 값을 모든 leg에 동일하게 적용한다.
 
+**leg 간 경로 겹침 방지(visited_nodes 페널티)**
+
+- `OnewayAstarEngine`/`OnewayBeamEngine`은 이제 선택적 생성자 파라미터 `visited_nodes: Optional[set] = None`을 받는다. 기본값(미지정, 빈 set)이면 기존 동작과 완전히 동일하다 — `route_service.py`가 단독으로 쓰는 일반 편도 요청에는 영향이 없다.
+- `WaypointComposerEngine.run()`은 leg마다 성공한 경로의 노드열을 `visited_nodes` 집합에 누적하고, 다음 leg의 엔진(재시도 포함)에 그 집합을 전달한다. 각 엔진은 `PathUtils.connect_to`의 `revisit_penalty`와 동일한 패턴(`_RETURN_REVISIT_PENALTY`, 5배)으로, 도착지 자신을 제외한 기방문 노드로 가는 엣지 가중치에 페널티를 곱해 우회를 유도한다.
+- `OnewayAstarEngine`은 `find_path()`가 최적화하는 가중치 함수 자체에 페널티가 들어가므로, 페널티가 있으면 순수 최단경로가 아니라 "기방문 노드를 피하는 최단경로"를 반환한다 — leg 라벨이 `oneway_shortest`여도 마찬가지다.
+- `OnewayBeamEngine`은 최종 경로 선택이 `target_km` 일치도를 최우선 기준(`_rank_key`의 첫 정렬 키)으로 삼기 때문에, 페널티가 최종 경로 선택에 항상 우선하지는 않는다 — 목표 거리에 더 가까운 경로가 있으면 페널티를 감수하고도 그 경로를 선택할 수 있다. 페널티는 후보 확장 단계(`_find_start_to_waypoint`의 cost 누적)와 도착 연결 단계(`_find_waypoint_to_end` → `connect_to`)에는 항상 반영되지만, 최종 승자가 반드시 우회로가 되는 것은 보장하지 않는다.
+- 각 엔진에는 `last_path_nodes` 속성이 추가됐다 — 가장 최근 `run()`이 실제로 사용한 노드열(`OnewayBeamEngine`은 왕복 가지 제거 후)이며, `WaypointComposerEngine`이 다음 leg의 `visited_nodes`를 누적할 때 이 값을 읽는다.
+- `GpsArtEngine`은 내부적으로 `WaypointComposerEngine`을 그대로 쓰므로 별도 수정 없이 이 겹침 방지 로직을 그대로 물려받는다 — 도형이 스스로 교차하는 경우 겹치는 구간을 우회하려고 시도한다(단, 위 `OnewayBeamEngine`의 한계와 동일하게 항상 보장되지는 않는다).
+
 ## GPS Art
 
 경유지 반영 경로를 응용해, 도형 모양대로 걷는 경로를 생성한다. route_engine 계산(`GpsArtEngine`)과 이미지 생성·윤곽선 추출(`GpsArtService`, `src/service/route/gps_art_service.py`) 두 layer로 나뉜다.

--- a/src/route_engine/engines/oneway_astar.py
+++ b/src/route_engine/engines/oneway_astar.py
@@ -2,7 +2,7 @@ import networkx as nx
 from typing import Optional, List
 import logging
 
-from src.route_engine.engines.path_utils import PathUtils
+from src.route_engine.engines.path_utils import PathUtils, _RETURN_REVISIT_PENALTY
 from src.route_engine.profiles import ScoringProfile, get_profile, merge_weights
 from src.interfaces.schema.walk_schema import (
     WalkMode,
@@ -21,6 +21,7 @@ class OnewayAstarEngine:
         G: nx.Graph,
         custom_weights: Optional[Weights] = None,
         profile: Optional[ScoringProfile] = None,
+        visited_nodes: Optional[set] = None,
     ):
         self.inp           = inp
         self.G             = G  # custom_score를 그래프에 쓰지 않으므로 copy() 불필요
@@ -33,6 +34,9 @@ class OnewayAstarEngine:
         self._weight_fn    = None
         self._score_lookup: dict = {}
         self._min_ratio    = 1.0
+        # WaypointComposerEngine이 leg 간 경로 겹침을 페널티로 방지할 때 채워줌. 기본(빈 set)이면 기존 동작과 동일.
+        self.visited_nodes = visited_nodes or set()
+        self.last_path_nodes: list[int] = []  # 가장 최근 run()이 실제로 사용한 노드열(WaypointComposerEngine이 다음 leg의 visited_nodes 누적에 사용)
 
     def run(self) -> List[WalkRouteResponse]:
         """
@@ -78,6 +82,7 @@ class OnewayAstarEngine:
             )]
 
         nodes     = candidates[0]                          # 경로 1개만 사용
+        self.last_path_nodes = nodes
         coords    = self.utils.extract_coordinates(nodes)
         total_m   = self.utils.calc_distance(nodes)
         total_km = round(total_m / 1000, 2)
@@ -95,11 +100,18 @@ class OnewayAstarEngine:
         """
         A* 알고리즘으로 최단 경로 노드 목록을 반환합니다.
         """
+        def _weight(u, v, d):
+            # PathUtils.connect_to와 동일한 패턴: 도착지 자신은 페널티 대상에서 제외한다.
+            base = self._weight_fn(u, v, d)
+            if v in self.visited_nodes and v != end:
+                return base * _RETURN_REVISIT_PENALTY
+            return base
+
         try:
             return [nx.astar_path(
                 self.G, start, end,
                 heuristic=self._heuristic,
-                weight=self._weight_fn,
+                weight=_weight,
             )]
         except nx.NetworkXNoPath:
             logger.warning("출발-도착 노드 사이에 연결된 경로가 없습니다")

--- a/src/route_engine/engines/oneway_beam.py
+++ b/src/route_engine/engines/oneway_beam.py
@@ -2,7 +2,7 @@ import networkx as nx
 from typing import Optional, List
 import logging
 
-from src.route_engine.engines.path_utils import PathUtils
+from src.route_engine.engines.path_utils import PathUtils, _RETURN_REVISIT_PENALTY
 from src.route_engine.profiles import ScoringProfile, get_profile, merge_weights
 from src.interfaces.schema.walk_schema import (
     WalkMode,
@@ -24,6 +24,7 @@ class OnewayBeamEngine:
         G: nx.Graph,
         custom_weights: Optional[Weights] = None,
         profile: Optional[ScoringProfile] = None,
+        visited_nodes: Optional[set] = None,
     ):
         self.inp           = inp
         self.G             = G.copy()  # 원본 그래프 보호
@@ -33,6 +34,9 @@ class OnewayBeamEngine:
         self.weights       = merge_weights(profile_config.weights, custom_weights)
         self.blocked_tags  = profile_config.blocked_tags
         self.scoring_mode  = profile_config.scoring_mode
+        # WaypointComposerEngine이 leg 간 경로 겹침을 페널티로 방지할 때 채워줌. 기본(빈 set)이면 기존 동작과 동일.
+        self.visited_nodes = visited_nodes or set()
+        self.last_path_nodes: list[int] = []  # 가장 최근 run()이 실제로 사용한 노드열(왕복 가지 제거 후)
 
     def run(self) -> List[WalkRouteResponse]:
         """
@@ -86,6 +90,7 @@ class OnewayBeamEngine:
 
         nodes    = candidates[0]                            # 경로 1개만 사용
         pruned   = self.utils.prune_dead_ends(nodes)       # 왕복 가지 제거
+        self.last_path_nodes = pruned
         coords   = self.utils.extract_coordinates(pruned)  # [lat, lon] 좌표 목록
         total_m  = self.utils.calc_distance(pruned)        # 총 이동 거리(m)
         total_km = round(total_m / 1000, 2)
@@ -208,8 +213,12 @@ class OnewayBeamEngine:
                         continue  # 노드 재방문 금지 → 단순 경로 → 왕복 가지 차단
 
                     edge = self.G.get_edge_data(current, n) or {}
+                    step_cost = edge.get("custom_score", 1.0)
+                    # leg 간 경로 겹침 방지: 다른 leg가 이미 지나간 노드면 페널티(도착지 자신은 제외)
+                    if n in self.visited_nodes and n != end:
+                        step_cost *= _RETURN_REVISIT_PENALTY
                     candidates.append((
-                        cost + edge.get("custom_score", 1.0),  # 누적 비용 갱신
+                        cost + step_cost,                      # 누적 비용 갱신
                         nodes + [n],                           # 노드열 갱신
                         dist + edge.get("length", 0),          # 누적 거리 갱신
                         visited | {n},                         # 방문 집합 갱신
@@ -233,5 +242,6 @@ class OnewayBeamEngine:
     def _find_waypoint_to_end(self, nodes: list[int], visited: set, end: int):
         """
         2단계: 한 후보의 중간지점 → 도착지 경로를 생성합니다.
+        leg 간 경로 겹침 방지를 위해 이 leg 내부 visited에 다른 leg의 visited_nodes도 합쳐서 넘긴다.
         """
-        return self.utils.connect_to(nodes, visited, end)
+        return self.utils.connect_to(nodes, visited | self.visited_nodes, end)

--- a/src/route_engine/engines/waypoint.py
+++ b/src/route_engine/engines/waypoint.py
@@ -60,6 +60,7 @@ class WaypointComposerEngine:
             (self.inp.end_lat, self.inp.end_lon),              # 목적지
         ]
 
+        visited_nodes: set = set()  # 앞선 leg들이 지나간 노드. 다음 leg 탐색에 겹침 페널티로 반영
         leg_results: List[WalkRouteResponse] = []
         for i, mode in enumerate(self.inp.leg_modes):
             start_lat, start_lon = stops[i]
@@ -73,6 +74,7 @@ class WaypointComposerEngine:
             )
             engine = _LEG_ENGINES[mode](
                 leg_inp, self.G, custom_weights=self.custom_weights, profile=self.profile,
+                visited_nodes=visited_nodes,
             )
             result = engine.run()[0]  # leg 엔진도 후보 리스트를 반환하므로 1개만 사용
 
@@ -80,10 +82,11 @@ class WaypointComposerEngine:
             if result.status != WalkRouteStatus.SUCCESS and mode != "oneway_shortest":
                 logger.warning("leg %d(%s)에서 실패해 최단 경로로 대체합니다: status=%s",
                                i + 1, mode, result.status.value)
-                fallback = OnewayAstarEngine(
+                engine = OnewayAstarEngine(
                     leg_inp, self.G, custom_weights=self.custom_weights, profile=self.profile,
+                    visited_nodes=visited_nodes,
                 )
-                result = fallback.run()[0]
+                result = engine.run()[0]
 
             leg_results.append(result)
 
@@ -92,6 +95,8 @@ class WaypointComposerEngine:
             if result.status != WalkRouteStatus.SUCCESS:
                 logger.warning("leg %d에서 최단 경로 대체도 실패해 이후 leg를 생략합니다: status=%s", i + 1, result.status.value)
                 break
+
+            visited_nodes.update(engine.last_path_nodes)  # 실제로 이 leg를 만든 엔진(재시도 포함)의 경로를 누적
 
         return [self._stitch(leg_results, len(self.inp.leg_modes))]
 


### PR DESCRIPTION
## ☝️Issue Number
- resolve #345 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- `WaypointComposerEngine`으로 경유지 경로(및 이를 재사용하는 GPS Art)를 생성할 때, 서로 다른 leg가 같은 도로 구간을 중복으로 지나가는 문제를 방지하는 로직 추가.
- `OnewayAstarEngine`/`OnewayBeamEngine`에 선택적 파라미터 `visited_nodes`를 추가. 기방문 노드로 가는 엣지에 `PathUtils.connect_to`가 이미 쓰던 것과 동일한 페널티(`_RETURN_REVISIT_PENALTY`, 5배)를 적용해 우회를 유도. 파라미터를 안 넘기면(기본값) 기존 동작과 완전히 동일 — 단독 편도 요청(`route_service.py`)에는 영향 없음.
- `WaypointComposerEngine.run()`이 leg마다 성공한 경로의 노드를 누적해 다음 leg(재시도 포함)에 전달. `GpsArtEngine`은 이 로직을 그대로 물려받아 별도 수정 없이 적용됨(도형이 스스로 교차할 때 겹치는 구간을 우회 시도).
- 각 엔진에 `last_path_nodes` 속성 추가(가장 최근 `run()`이 실제로 사용한 노드열).
