### PR TITLE
feat: 날씨 조회 결과 캐싱

### DIFF
--- a/scripts/test_weather_cache.py
+++ b/scripts/test_weather_cache.py
@@ -1,0 +1,62 @@
+"""
+WeatherChecker의 Valkey 캐싱을 검증하는 일회성 스크립트.
+같은 좌표로 두 번 호출해서, 두 번째 호출은 실제 API를 부르지 않고 캐시된 값을 쓰는지 확인합니다.
+실행: poetry run python scripts/test_weather_cache.py
+(Valkey가 떠 있어야 합니다. DB·경로 그래프는 필요 없습니다.)
+"""
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from src.agent.nodes.weather_checker import WeatherChecker
+from src.infrastructure.external.client.weather_client import WeatherClient
+from src.infrastructure.external.client.kakao_client import KakaoClient
+from src.infrastructure.cache.valkey import get_valkey_db
+
+LAT, LON = 37.5665, 126.9780  # 서울시청
+
+
+async def main():
+    weather_client = WeatherClient(KakaoClient())
+    checker = WeatherChecker(weather_client=weather_client)
+
+    # 이전 실행에서 남은 캐시 제거
+    nx, ny = weather_client.get_nx_and_ny(LAT, LON)
+    redis = get_valkey_db()
+    await redis.delete(f"weather:{nx}:{ny}", f"air_quality:{nx}:{ny}")
+    print(f"[0] 격자 좌표: nx={nx}, ny={ny} (캐시 초기화 완료)")
+
+    fake_weather = {"temperature": "20℃"}
+    fake_air = {"pm10": "30㎍/㎥"}
+
+    with patch.object(weather_client, "get_weather", AsyncMock(return_value=fake_weather)) as mock_weather, \
+         patch.object(weather_client, "get_air_quality", AsyncMock(return_value=fake_air)) as mock_air:
+
+        # 1차 호출 -> 캐시 없음 -> mock API가 호출돼야 함
+        await checker.run(LAT, LON)
+        print(f"[1] 1차 호출 후 get_weather 호출 횟수: {mock_weather.call_count}")
+        print(f"[1] 1차 호출 후 get_air_quality 호출 횟수: {mock_air.call_count}")
+        assert mock_weather.call_count == 1
+        assert mock_air.call_count == 1
+        print("[1] PASS")
+
+        # 2차 호출(같은 좌표) -> 캐시 히트 -> mock API 호출 횟수가 그대로여야 함
+        await checker.run(LAT, LON)
+        print(f"[2] 2차 호출 후 get_weather 호출 횟수: {mock_weather.call_count}")
+        print(f"[2] 2차 호출 후 get_air_quality 호출 횟수: {mock_air.call_count}")
+        assert mock_weather.call_count == 1, "캐시 히트인데 API가 다시 호출됐습니다."
+        assert mock_air.call_count == 1, "캐시 히트인데 API가 다시 호출됐습니다."
+        print("[2] PASS: 두 번째 호출에서 캐시가 재사용됐습니다.")
+
+    # TTL 확인
+    ttl_weather = await redis.ttl(f"weather:{nx}:{ny}")
+    ttl_air = await redis.ttl(f"air_quality:{nx}:{ny}")
+    print(f"[3] weather TTL: {ttl_weather}초, air_quality TTL: {ttl_air}초")
+    assert 0 < ttl_weather <= 1800
+    assert 0 < ttl_air <= 1800
+    print("[3] PASS: TTL이 30분 이내로 설정되어 있습니다.")
+
+    print("\n모두 통과했습니다.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/agent/nodes/weather_checker.py
+++ b/src/agent/nodes/weather_checker.py
@@ -4,6 +4,7 @@ from langchain_core.output_parsers import StrOutputParser
 
 from src.infrastructure.external.client.gpt_client import GPTClient
 from src.infrastructure.external.client.weather_client import WeatherClient
+from src.infrastructure.cache.repository.weather_cache_repository import WeatherCacheRepository
 
 logger = logging.getLogger(__name__)
 
@@ -17,15 +18,26 @@ class WeatherChecker(GPTClient):
     async def run(self, lat: float, lon: float) -> str:
         """
         날씨·대기질 조회 후 LLM으로 친절한 첫 인사 메시지를 생성하여 반환합니다.
+        같은 기상청 격자(nx, ny) 안에서는 Valkey에 30분간 캐싱된 값을 재사용합니다.
         """
+        nx, ny = self.weather_client.get_nx_and_ny(lat, lon)
+
         try:
-            weather_info = await self.weather_client.get_weather(lat, lon)
+            weather_info = await WeatherCacheRepository.get_weather(nx, ny)
+            if weather_info is None:
+                weather_info = await self.weather_client.get_weather(lat, lon)
+                if weather_info:
+                    await WeatherCacheRepository.save_weather(nx, ny, weather_info)
         except Exception:
             logger.exception("weather_api_error | lat=%s | lon=%s", lat, lon)
             weather_info = None
 
         try:
-            air_info = await self.weather_client.get_air_quality(lat, lon)
+            air_info = await WeatherCacheRepository.get_air_quality(nx, ny)
+            if air_info is None:
+                air_info = await self.weather_client.get_air_quality(lat, lon)
+                if air_info:
+                    await WeatherCacheRepository.save_air_quality(nx, ny, air_info)
         except Exception:
             logger.exception("air_quality_api_error | lat=%s | lon=%s", lat, lon)
             air_info = None


### PR DESCRIPTION
## ☝️Issue Number
- resolve #348

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 새 `WeatherCacheRepository`(Valkey) 추가 — `weather:{nx}:{ny}`, `air_quality:{nx}:{ny}` 키로 TTL 30분(1800초) 캐싱
- `weather_checker.py`에서 캐시 조회 → 없으면 API 호출 → 성공한 경우에만 캐시 저장하도록 수정(실패/None 결과는 캐싱하지 않아 API 일시 장애가 30분간 캐시에 고정되는 것 방지)
- 캐시 키는 위경도를 직접 쓰지 않고 `weather_client.get_nx_and_ny`(기상청 격자 좌표 변환)를 재사용 — 같은 좌표로 2회 호출 시 1차만 실제 API 호출, 2차는 캐시 히트로 API 호출 0회 확인 + TTL 30분 이내 확인(mock 기반 스크립트로 PASS)

## 👀 ETC
- 캐시 키 설계는 위경도를 별도로 반올림/그리드화하지 않고, 이미 있던 기상청 격자 좌표(nx, ny) 변환 함수를 그대로 재사용함 — 날씨 API 자체가 이 격자 단위로 조회되므로 같은 격자=같은 응답이 보장되고, 외부 호출 없이 순수 계산으로 캐시 키를 구할 수 있음
- 대기질(`get_air_quality`)도 같은 nx/ny 격자를 캐시 키로 재사용 — 원래는 좌표→Kakao 역지오코딩→자치구명 순으로 조회하는데, 캐시 히트 시 이 Kakao 호출까지 생략됨(5km 격자가 자치구 크기와 비슷해 근사치로 허용)
- LLM이 생성하는 인사 문구 자체는 캐싱 대상에서 제외(매번 새로 생성)