### PR TITLE
Refactor/358

### DIFF
--- a/docs/chatbot/agent_harness.md
+++ b/docs/chatbot/agent_harness.md
@@ -1,9 +1,9 @@
 # 챗봇 Agent 하네스
 
 > 상태: Current  
-> 기준일: 2026-08-07  
+> 기준일: 2026-08-08  
 > 관련 코드: `src/agent/`, `src/service/chat/prewalk_service.py`, `src/schema/prewalk_schema.py`  
-> 검증 상태: 코드 정적 대조 완료(2026-07-30, `ConfirmationClassifier` 추가·Graph 재배선·dev PR #310 profile/nearby_pois 반영) + `ConfirmationClassifier`·조건부 진입점 실행 검증 완료(2026-07-30, 로컬 PostgreSQL·Valkey·실제 Kakao·OpenAI, 프런트엔드 연동 안드로이드 기기 테스트). profile/nearby_pois(dev PR #310)는 정적 대조만 했고 격리 환경 실행 검증은 별도로 안 함. GPS Art 모드 배선(2026-08-06)은 정적 대조·문법 체크만 했고 실행 검증은 안 함(전용 테스트도 아직 없음) — 상세는 [경로 생성 엔진 GPS Art](../route_engine/README.md#gps-art) 참고. Waypoint 모드 배선(2026-08-07)은 정적 대조 + 단위 테스트(mock 엔진 기반)까지 확인했고, 추출·인터뷰 prompt 가이드(2026-08-07 추가)도 정적 대조(YAML 파싱·렌더링 확인)만 했다 — 실제 LLM·Kakao·그래프 실행 검증은 아직 없다 — 상세는 [경로 생성 엔진](../route_engine/README.md) 참고
+> 검증 상태: 코드 정적 대조 완료(2026-07-30, `ConfirmationClassifier` 추가·Graph 재배선·dev PR #310 profile/nearby_pois 반영) + `ConfirmationClassifier`·조건부 진입점 실행 검증 완료(2026-07-30, 로컬 PostgreSQL·Valkey·실제 Kakao·OpenAI, 프런트엔드 연동 안드로이드 기기 테스트). profile/nearby_pois(dev PR #310)는 정적 대조만 했고 격리 환경 실행 검증은 별도로 안 함. GPS Art 모드 배선(2026-08-06)은 정적 대조·문법 체크만 했고 실행 검증은 안 함(전용 테스트도 아직 없음) — 상세는 [경로 생성 엔진 GPS Art](../route_engine/README.md#gps-art) 참고. Waypoint 모드 배선(2026-08-07)은 정적 대조 + 단위 테스트(mock 엔진 기반)까지 확인했고, 추출·인터뷰 prompt 가이드(2026-08-07 추가)도 정적 대조(YAML 파싱·렌더링 확인)만 했다 — 실제 LLM·Kakao·그래프 실행 검증은 아직 없다 — 상세는 [경로 생성 엔진](../route_engine/README.md) 참고. `circular_random`/`oneway_random`의 후보 다양화(벡터 score, 2026-08-08)는 toy 그래프로 직접 실행 검증했지만 정식 `tests/` 회귀 테스트와 실서비스 그래프 검증은 아직 없다 — 상세는 [경로 생성 엔진](../route_engine/README.md)의 "후보 다양화(벡터 score 기반)" 절 참고
 
 ## 1. 책임
 
@@ -53,8 +53,9 @@ HTTP 입력:
 - API 출력: `ChatResponse(status, thread_id, state)`
 - PostgreSQL: init마다 `ChatSession(user_id, thread_id, START)` 추가
 - Valkey: `chat_state:{thread_id}`에 전체 State JSON 저장, TTL 3,600초
-- 경로 성공: `RouteService`가 `RouteHistory`를 저장하고 `route_result.id` 반환
-- 경로 성공: 경로 50m 안의 도보망 연결 POI를 `route_result.nearby_pois`로 반환
+- 경로 성공: `route_result`(`List[WalkRouteResponse]`)는 모드에 따라 최대 3개까지 담길 수 있다(`circular_random`/`oneway_random`은 벡터 기반으로 다양화한 후보 최대 3개, 그 외 모드는 1개 — 상세는 [경로 생성 엔진](../route_engine/README.md)의 "후보 다양화(벡터 score 기반)" 절 참고)
+- 경로 성공: `RouteService`가 `RouteHistory`를 저장하고 `route_result[0].id`(대표 후보만)에 반영한다 — 나머지 후보의 `id`는 비어 있다(사용자가 실제로 고른 후보를 저장하는 흐름은 아직 없음, 알려진 개선 항목)
+- 경로 성공: 성공한 후보 전부에 대해 그 경로 50m 안의 도보망 연결 POI를 `route_result[i].nearby_pois`로 반환
 - LLM 출력: 초기 인사, 모드·거리·위치·테마 추출, 누락 질문, 확인 질문 긍정·부정 판정
 
 현재 intent State에는 access JWT가 포함되며 API 응답과 Valkey JSON 양쪽으로 전달된다. `ChatSession.current_state`는 경로 완료 후에도 `START`로 남는다.

--- a/docs/route_engine/README.md
+++ b/docs/route_engine/README.md
@@ -1,7 +1,7 @@
 # 경로 생성 엔진
 
 > 상태: Current
-> 기준일: 2026-08-07
+> 기준일: 2026-08-08
 > 관련 코드: `src/route_engine/`
 
 경로 생성 엔진은 외부 API나 챗봇 처리와 분리된 경로 계산 영역입니다.
@@ -23,10 +23,51 @@
 
 - `circular_beam`(`CircularBeamEngine`)·`oneway_beam`(`OnewayBeamEngine`)·`oneway_astar`(`OnewayAstarEngine`)·`gps_art`(`GpsArtEngine`)·`waypoint`(`WaypointComposerEngine`) 5개 엔진의 `run()`은 모두 `List[WalkRouteResponse]`를 반환한다.
 - 이 중 `circular_beam`·`oneway_beam`·`oneway_astar`의 `find_path()`는 노드ID 경로 후보를 `list[list[int]]`로 감싸서 반환한다. `gps_art`·`waypoint`는 자체 `find_path()`가 없다 — 대신 다른 엔진들의 `run()` 결과를 조합(`WaypointComposerEngine`)하거나 그 조합에 위임(`GpsArtEngine`)해서 최종 경로를 만든다.
-- 현재는 항상 경로 1개만 생성해 리스트에 담아 반환한다. 여러 경로 후보를 동시에 생성하는 기능은 아직 구현하지 않았다.
+- `circular_random`·`oneway_random`은 2026-08-07부터 최대 3개까지 벡터로 다양화한 후보를 반환한다(상세는 아래 "후보 다양화(벡터 score 기반)" 절 참고). `oneway_shortest`·GPS Art, 그리고 경유지 조합 중 다양화할 대안이 없는 경우(예: 모든 leg가 `oneway_shortest`)는 여전히 1개만 반환한다.
 - `oneway_shortest` 모드의 실제 사용 엔진은 `dijkstra.py`(`OnewayDijkstraEngine`)에서 `oneway_astar.py`(`OnewayAstarEngine`)로 교체되었다. 배경·현재 사용처는 바로 아래 "oneway_shortest 엔진: Dijkstra → A*(ALT) 교체" 절 참고.
-- `route_service.get_route()`도 같은 계약(`List[WalkRouteResponse]`)으로 반환하며, 리스트의 첫 번째 요소만 사용해 POI 조회·이력 저장을 수행하고 리스트 전체를 그대로 반환한다.
+- `route_service.get_route()`도 같은 계약(`List[WalkRouteResponse]`)으로 반환한다. POI 조회는 성공한 후보 전부에 적용하고, `RouteHistory` 저장은 아직 대표 후보(리스트의 첫 번째)만 한다 — 사용자가 실제로 어떤 후보를 골랐는지 아직 API로 전달받지 않기 때문이며, 그 흐름이 생기면 선택된 후보를 저장하도록 바꿀 예정이다(`route_service.py`의 `TODO` 주석 참고). 리스트 전체는 그대로 반환한다.
 - `OnewayAstarEngine._heuristic`은 그래프 로드 시 `precompute_landmarks(G)`(`oneway_astar.py`)가 미리 채워둔 노드 속성 `landmark_dist`를 그대로 참조한다. 이 함수는 2026-08-07 이전까지 `benchmarks/*.py`에서만 호출됐고 `dependencies.init_route_service()`(실제 서버·스크립트 부팅 경로)에는 연결돼 있지 않아서, 그래프가 정상 로드돼도 `oneway_shortest`·GPS Art(내부적으로 `WaypointComposerEngine`을 거쳐 `OnewayAstarEngine`을 씀) 둘 다 A* 탐색 단계에서 `KeyError: 'landmark_dist'`로 실패했다(그래프 미로딩으로 인한 `NO_NEAREST_START_NODE`에 가려져 있다가 그래프 데이터 복구 후 GPS Art 실행 검증 중 드러남). `dependencies.py`의 `init_route_service()`에 `precompute_landmarks(G)` 호출을 추가해 수정했다(2026-08-07).
+
+## 후보 다양화(벡터 score 기반)
+
+**왜 필요한가**
+
+- beam search(`oneway_beam.py`/`circular_beam.py`)는 내부적으로 여러 후보(`_BEAM_WIDTH=8`)를 유지하다가도, 최종적으로는 안전·자연·평지 등을 전부 하나의 스칼라(`custom_score`)로 블렌딩한 기준 하나로만 후보를 좁혔다 — 그래서 여러 개를 뽑아도 사실상 비슷한 경로만 나오는 문제가 있었다.
+- `target_km`(거리 허용오차) 자체는 이 다양화와 무관하게 여전히 1순위 조건이다 — 벡터 비교는 목표 거리를 만족(또는 가장 근접)하는 후보 풀 안에서만 적용한다.
+
+**벡터 score — `scoring_engine.py`**
+
+- `compute_score_vector(graph) -> {(u, v): {"safety": cost, "nature": cost, "slope": cost, "convenience": cost, "accessibility": cost}, ...}`를 추가했다. 기존 `calculate_custom_score`/`compute_custom_score_lookup`은 전혀 수정하지 않았다 — 그래서 A*(`oneway_astar.py`의 ALT `min_ratio`)·GRASP·ALNS·RCSP 등 이 스코어 함수를 공유하는 다른 엔진에는 영향이 없다.
+- 각 차원 값은 `length * (1 - feature)`다. `feature`(0~1, 1이 가장 좋음)가 1이면 0, 0이면 그 edge의 `length` 전체가 비용이 된다 — `custom_score`처럼 경로를 따라 그대로 합산할 수 있고, 모든 차원이 이미 미터 단위라 추가 정규화 없이 비교 가능하다.
+- profile 가중치를 받지 않는다 — 대표 후보(아래 "후보 1")는 기존처럼 요청받은 profile의 가중 스칼라로 뽑고, 이 벡터는 나머지 후보를 가중치와 무관하게 다양화하는 용도로만 쓴다.
+
+**경로별 벡터 합산과 다양화 선택 — `path_utils.py`**
+
+- `PathUtils.path_score_vector(path, vector_lookup)`: `metrics()`가 `custom_score`를 합산하는 것과 같은 패턴으로, 경로를 따라 벡터를 성분별로 합산한다.
+- `PathUtils.vector_distance(a, b)`: 두 벡터 사이 유클리드 거리.
+- `PathUtils.select_diverse_paths(candidates, k=3)`: **후보 1**(`candidates[0]`, 호출부가 기존 스칼라 키로 이미 정한 대표)을 고정하고, 나머지 중 이미 뽑힌 것들과의 최소거리가 가장 큰 것을 greedy farthest-point(k-center) 방식으로 최대 `k-1`개 더 뽑는다. 최댓값이 아니라 **최솟값의 최댓값**을 기준으로 삼는 이유는, "다른 후보와는 멀어도 기존에 뽑힌 것 중 하나와 거의 같은" 사실상의 중복을 배제하기 위해서다. 후보가 `k`개 미만이면 있는 만큼만 반환한다. `payload` 자리에는 노드 ID 리스트뿐 아니라 `WalkRouteResponse` 등 어떤 타입도 그대로 통과시킬 수 있다(`TypeVar` 기반 제네릭).
+
+**`oneway_beam.py`/`circular_beam.py`: 최종 3개 선택**
+
+- 도착(또는 복귀) 연결에 성공한 완성 후보 전체를 모아 기존 정렬 키(`oneway_beam`은 `(over, overlap, density)`, `circular_beam`은 `(over, density)`)로 정렬한다. `over`(거리 허용오차)와 `overlap`(우회도, `oneway_beam` 전용)은 벡터에 넣지 않는다 — 둘 다 "이 모드에서 유효한 후보인가"를 정하는 조건이라, 트레이드오프 대상인 품질 벡터와 성격이 다르기 때문이다.
+- **후보 1** = 이 정렬 키 기준 최상위(오늘까지의 단일 결과와 완전히 동일). **후보 2·3** = 후보 1과 같은 거리 등급(`over`가 같은 값)을 만족하는 후보들 안에서만, `compute_score_vector`로 계산한 5차원 벡터를 `select_diverse_paths`로 다양화해서 뽑는다.
+- `OnewayBeamEngine`에 `last_path_nodes_by_candidate: list[list[int]]`를 추가했다 — 반환하는 모든 후보의 노드열을 반환 순서대로 보관한다. 기존 `last_path_nodes`(단일 필드)는 후보 1의 단축값으로 그대로 남겨 하위 호환을 유지한다. `OnewayAstarEngine`에도 인터페이스를 맞추기 위해 `last_path_nodes_by_candidate = [last_path_nodes]`(항상 후보 1개뿐이라 트리비얼)를 추가했다.
+- `CircularBeamEngine`은 `last_path_nodes` 계열 자체가 없다 — `WaypointLegMode`가 `oneway_shortest`/`oneway_random`만 허용해서(`route_schema.py`) 순환 모드는 구조적으로 waypoint leg가 될 수 없고, 따라서 cross-leg 겹침 방지 대상이 아니기 때문이다.
+
+**`waypoint.py`: leg 조합에도 다양화 전파**
+
+- `WaypointComposerEngine`이 leg 엔진을 호출할 때 이제 그 leg의 전체 후보 리스트(`engine.run()`)와 노드열 리스트(`engine.last_path_nodes_by_candidate`)를 둘 다 보관한다. 상태 판정·재시도(`oneway_shortest`로 대체)·`visited_nodes` 누적은 기존처럼 대표 후보(인덱스 0) 기준으로만 한다.
+- 모든 leg가 성공했을 때만: leg별로 같은 인덱스(0/1/2)끼리 짝지어 이어붙인 "슬롯" 최대 3개를 만든다(leg에 그 인덱스의 후보가 없으면 대표로 대체 — 예: `oneway_shortest` leg는 항상 대표만 있음). 슬롯 중 노드열이 완전히 같은 것(예: 전 leg가 `oneway_shortest`라 애초에 대안이 없는 경우)은 버리고, 남은 슬롯들의 전체 경로 벡터를 계산해 `select_diverse_paths`로 최종 정리한다.
+- 이 방식은 leg 개수와 무관하게 항상 최대 3개만 계산한다 — leg별 후보를 전부 조합(3^legs)하지는 않는다. 일부 leg가 실패한 경우엔 다양화 없이 기존처럼 대표 경로 1개만 이어붙여 반환한다(부분/실패 경로까지 3개로 부풀리지 않음).
+- 검증: 단일 leg(순수 `oneway_random`), 2-leg(경유지 1개, 양쪽 다 `oneway_random`, 각각 3-lane), 2-leg 전부 `oneway_shortest`(대안 없음, degenerate case) 세 시나리오를 실제 toy 그래프로 직접 실행해 각각 3개/3개/1개(중복 제거 확인)가 나오는 것까지 확인했다(2026-08-07). **정식 `tests/` 회귀 테스트로는 아직 옮기지 않았다** — 지금까지는 임시 스크립트로만 검증했다.
+
+**`route_service.py`: POI·이력 처리**
+
+- POI 조회(`RoutePoiRepository.find_near_route`)는 성공한 후보 전부에 적용한다.
+- `RouteHistory` 저장은 아직 대표 후보(리스트의 첫 번째)만 한다 — 사용자가 실제로 어떤 후보를 선택했는지 API로 전달받는 흐름이 아직 없기 때문이다. **알려진 개선 항목**: 그 흐름이 생기면 사용자가 실제로 고른 후보를 저장하도록 바꿀 예정이다(`route_service.py`의 `TODO` 주석 참고).
+- `walk_router.py`(직접 REST API)는 의도적으로 이번 변경 범위에서 제외했다 — 레거시로 간주하기로 했고, `response.status.value`가 이미 실제 반환 타입(`List[...]`)과 맞지 않는 기존 버그도 그대로 둔다.
+
+**아직 확인 안 된 것**: 실제 그래프 규모에서 이 다양화가 실제로 서로 다른 "의미 있는" 3개(예: 정말 확연히 다른 동선)를 만들어내는지는 toy 그래프 검증까지만 했고, 실서비스 규모 그래프·프런트엔드 노출까지는 확인하지 않았다. `tests/`에 정식 회귀 테스트도 아직 없다.
 
 ## oneway_shortest 엔진: Dijkstra → A*(ALT) 교체
 

--- a/src/route_engine/engines/circular_beam.py
+++ b/src/route_engine/engines/circular_beam.py
@@ -10,7 +10,7 @@ from src.interfaces.schema.walk_schema import (
     WalkRouteResponse
 )
 from src.schema.route_schema import CircularRouteInput, Weights
-from src.route_engine.scoring.scoring_engine import calculate_custom_score
+from src.route_engine.scoring.scoring_engine import calculate_custom_score, compute_score_vector
 
 logger = logging.getLogger(__name__)
 
@@ -76,20 +76,25 @@ class CircularBeamEngine:
                 total_km=0.0,
             )]
 
-        nodes    = candidates[0]                            # 경로 1개만 사용
-        pruned   = self.utils.prune_dead_ends(nodes)       # 왕복 가지 제거
-        coords   = self.utils.extract_coordinates(pruned)  # [lat, lon] 좌표 목록
-        total_m  = self.utils.calc_distance(pruned)        # 총 이동 거리(미터)
-        total_km = round(total_m / 1000, 2)
+        # find_path()가 최대 3개까지 다양화한 후보를 반환함 — 각각을 응답으로 변환
+        # (순환은 waypoint leg로 쓰이지 않아 last_path_nodes 계열은 두지 않는다)
+        responses: List[WalkRouteResponse] = []
+        for nodes in candidates:
+            pruned   = self.utils.prune_dead_ends(nodes)       # 왕복 가지 제거
+            coords   = self.utils.extract_coordinates(pruned)  # [lat, lon] 좌표 목록
+            total_m  = self.utils.calc_distance(pruned)        # 총 이동 거리(미터)
+            total_km = round(total_m / 1000, 2)
+            responses.append(WalkRouteResponse(
+                status          = WalkRouteStatus.SUCCESS if coords else WalkRouteStatus.NO_PATH,
+                mode            = self.mode,
+                coordinates     = coords,
+                total_km        = total_km,
+            ))
 
-        logger.info("경로 생성 완료: total_km=%.2f (target=%.2f), 노드=%d개", total_km, self.inp.target_km or 3.0, len(nodes))
+        logger.info("생성된 후보 수: %d, total_km=%s (target=%.2f)",
+                    len(responses), [r.total_km for r in responses], self.inp.target_km or 3.0)
 
-        return [WalkRouteResponse(
-            status          = WalkRouteStatus.SUCCESS if coords else WalkRouteStatus.NO_PATH,
-            mode            = self.mode,
-            coordinates     = coords,
-            total_km        = total_km,
-        )]
+        return responses
 
     def find_path(self, start_node: int, target_km: float = 3.0) -> list[list[int]]:
         """
@@ -106,24 +111,36 @@ class CircularBeamEngine:
             logger.warning("beam search 후보가 비어 출발 노드만 반환합니다.")
             return [[start_node]]
 
-        # 2단계: 반환점 → 출발지 + 가장 좋은 완성 경로 1개 채택
-        best_path, best_key = None, None
+        # 2단계: 반환점 → 출발지 연결에 성공한 완성 후보를 모두 모은다
+        closed_candidates: list[tuple[tuple, list[int]]] = []  # [(key, path), ...]
         for cost, nodes, dist, visited in pool:
             closed = self._find_waypoint_to_start(nodes, visited, start_node)
             if closed is None:
                 continue  # 출발점으로 복귀 불가한 후보는 제외
             key = self.utils.route_key(closed, target_m)  # (|실제 오차| - 허용 오차, 누적 비용 / 거리, 노드열)
-            if best_key is None or key < best_key:
-                best_key, best_path = key, closed
+            closed_candidates.append((key, closed))
 
         # 모든 후보가 복귀에 실패한 경우의 방어 코드
-        if best_path is None:
+        if not closed_candidates:
             logger.warning("복귀 가능한 후보가 없어 첫 후보의 바깥 경로를 반환합니다.")
             return [pool[0][1]]
 
-        logger.info("beam search 경로 선택: 노드=%d개, 거리초과=%.0fm, 품질밀도=%.3f",
+        # 후보 1: 기존과 동일하게 (거리 합격 → 품질밀도) 기준 최상위
+        closed_candidates.sort(key=lambda item: item[0])
+        best_key, best_path = closed_candidates[0]
+        logger.info("beam search 경로 선택(대표): 노드=%d개, 거리초과=%.0fm, 품질밀도=%.3f",
                     len(best_path), best_key[0], best_key[1])
-        return [best_path]
+
+        # 후보 2·3: 대표와 같은 거리 등급(over)을 만족하는 후보들 안에서만
+        # safety/nature/slope/convenience/accessibility 벡터로 다양화한다.
+        qualifying = [(key, path) for key, path in closed_candidates if key[0] == best_key[0]]
+
+        vector_lookup = compute_score_vector(self.G)
+        diversity_candidates = [
+            (self.utils.path_score_vector(path, vector_lookup), path)
+            for _, path in qualifying
+        ]
+        return self.utils.select_diverse_paths(diversity_candidates, k=3)
 
     def _find_start_to_waypoint(self, start_node: int, target_m: float) -> tuple:
         """

--- a/src/route_engine/engines/oneway_astar.py
+++ b/src/route_engine/engines/oneway_astar.py
@@ -37,6 +37,10 @@ class OnewayAstarEngine:
         # WaypointComposerEngine이 leg 간 경로 겹침을 페널티로 방지할 때 채워줌. 기본(빈 set)이면 기존 동작과 동일.
         self.visited_nodes = visited_nodes or set()
         self.last_path_nodes: list[int] = []  # 가장 최근 run()이 실제로 사용한 노드열(WaypointComposerEngine이 다음 leg의 visited_nodes 누적에 사용)
+        # OnewayBeamEngine과 인터페이스를 맞추기 위한 필드. A*는 항상 후보가 1개뿐이라
+        # 실질적으로 [last_path_nodes]와 같지만, WaypointComposerEngine이 leg 엔진 종류와
+        # 무관하게 같은 방식으로 후보별 노드열을 조회할 수 있게 해준다.
+        self.last_path_nodes_by_candidate: list[list[int]] = []
 
     def run(self) -> List[WalkRouteResponse]:
         """
@@ -83,6 +87,7 @@ class OnewayAstarEngine:
 
         nodes     = candidates[0]                          # 경로 1개만 사용
         self.last_path_nodes = nodes
+        self.last_path_nodes_by_candidate = [nodes]
         coords    = self.utils.extract_coordinates(nodes)
         total_m   = self.utils.calc_distance(nodes)
         total_km = round(total_m / 1000, 2)

--- a/src/route_engine/engines/oneway_beam.py
+++ b/src/route_engine/engines/oneway_beam.py
@@ -10,7 +10,7 @@ from src.interfaces.schema.walk_schema import (
     WalkRouteResponse
 )
 from src.schema.route_schema import OnewayRouteInput, Weights
-from src.route_engine.scoring.scoring_engine import calculate_custom_score
+from src.route_engine.scoring.scoring_engine import calculate_custom_score, compute_score_vector
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,8 @@ class OnewayBeamEngine:
         self.scoring_mode  = profile_config.scoring_mode
         # WaypointComposerEngine이 leg 간 경로 겹침을 페널티로 방지할 때 채워줌. 기본(빈 set)이면 기존 동작과 동일.
         self.visited_nodes = visited_nodes or set()
-        self.last_path_nodes: list[int] = []  # 가장 최근 run()이 실제로 사용한 노드열(왕복 가지 제거 후)
+        self.last_path_nodes: list[int] = []  # 후보 1(run()[0])의 노드열(왕복 가지 제거 후) — 하위 호환용 단축 값
+        self.last_path_nodes_by_candidate: list[list[int]] = []  # run()이 반환한 모든 후보의 노드열(반환 순서와 동일)
 
     def run(self) -> List[WalkRouteResponse]:
         """
@@ -88,21 +89,32 @@ class OnewayBeamEngine:
                 total_km=0.0,
             )]
 
-        nodes    = candidates[0]                            # 경로 1개만 사용
-        pruned   = self.utils.prune_dead_ends(nodes)       # 왕복 가지 제거
-        self.last_path_nodes = pruned
-        coords   = self.utils.extract_coordinates(pruned)  # [lat, lon] 좌표 목록
-        total_m  = self.utils.calc_distance(pruned)        # 총 이동 거리(m)
-        total_km = round(total_m / 1000, 2)
+        # find_path()가 최대 3개까지 다양화한 후보를 반환함 — 각각을 응답으로 변환
+        responses: List[WalkRouteResponse] = []
+        for i, nodes in enumerate(candidates):
+            pruned = self.utils.prune_dead_ends(nodes)  # 왕복 가지 제거
+            # 반환하는 모든 후보의 노드열을 인덱스별로 보관 — WalkRouteResponse에는
+            # 좌표만 있고 노드 ID가 없어서, 나중에 호출자가 후보 1이 아닌 다른 후보를
+            # 선택하더라도(예: WaypointComposerEngine이 leg 선택 로직을 바꾸는 경우)
+            # 그 후보의 실제 노드열을 되찾을 수 있게 하기 위함.
+            self.last_path_nodes_by_candidate.append(pruned)
+            if i == 0:
+                # 하위 호환용 — 지금의 WaypointComposerEngine은 항상 후보 1(run()[0])만
+                # 쓰므로 last_path_nodes는 그 경우를 위한 단축 값이다.
+                self.last_path_nodes = pruned
+            coords   = self.utils.extract_coordinates(pruned)  # [lat, lon] 좌표 목록
+            total_m  = self.utils.calc_distance(pruned)        # 총 이동 거리(m)
+            total_km = round(total_m / 1000, 2)
+            responses.append(WalkRouteResponse(
+                status          = WalkRouteStatus.SUCCESS if coords else WalkRouteStatus.NO_PATH,
+                mode            = self.mode,
+                coordinates     = coords,
+                total_km        = total_km,
+            ))
 
-        logger.info(f"total_km: {total_km}")
+        logger.info(f"생성된 후보 수: {len(responses)}, total_km: {[r.total_km for r in responses]}")
 
-        return [WalkRouteResponse(
-            status          = WalkRouteStatus.SUCCESS if coords else WalkRouteStatus.NO_PATH,
-            mode            = self.mode,
-            coordinates     = coords,
-            total_km        = total_km,
-        )]
+        return responses
 
     def find_path(self, start: int, end: int, target_km: float = 3.0) -> list[list[int]]:
         """
@@ -131,8 +143,8 @@ class OnewayBeamEngine:
             logger.warning("beam search 후보가 비어 최단 경로로 대체합니다.")
             return [base_shortest]
 
-        # 2단계: 중간지점 → 도착지 + 가장 좋은 완성 경로 1개 채택
-        best_path, best_key = None, None
+        # 2단계: 중간지점 → 도착지 연결에 성공한 완성 후보를 모두 모은다
+        closed_candidates: list[tuple[tuple, list[int]]] = []  # [(key, path), ...]
         for cost, nodes, dist, visited in pool:
             closed = self._find_waypoint_to_end(nodes, visited, end)
             if closed is None:
@@ -140,17 +152,31 @@ class OnewayBeamEngine:
             over, density, path_tuple = self.utils.route_key(closed, target_m)
             overlap = self._overlap_ratio(closed, base_edges)
             key = (over, overlap, density, path_tuple)  # 거리 합격 → 우회도 → 품질밀도 순으로 비교
-            if best_key is None or key < best_key:
-                best_key, best_path = key, closed
+            closed_candidates.append((key, closed))
 
         # 모든 후보가 도착 연결에 실패한 경우의 방어 코드
-        if best_path is None:
+        if not closed_candidates:
             logger.warning("도착 연결 가능한 후보가 없어 최단 경로로 대체합니다.")
             return [base_shortest]
 
-        logger.info("beam search 편도 경로 선택: 노드=%d개, 거리초과=%.0fm, 우회도=%.3f, 품질밀도=%.3f",
+        # 후보 1: 기존과 동일하게 (거리 합격 → 우회도 → 품질밀도) 기준 최상위
+        closed_candidates.sort(key=lambda item: item[0])
+        best_key, best_path = closed_candidates[0]
+        logger.info("beam search 편도 경로 선택(대표): 노드=%d개, 거리초과=%.0fm, 우회도=%.3f, 품질밀도=%.3f",
                     len(best_path), best_key[0], best_key[1], best_key[2])
-        return [best_path]
+
+        # 후보 2·3: 대표와 같은 거리 등급(over)을 만족하는 후보들 안에서만
+        # safety/nature/slope/convenience/accessibility 벡터로 다양화한다.
+        # (over가 0.0으로 정확히 겹치는 경우가 흔해 그룹핑 기준으로 안전하지만,
+        #  overlap/density는 연속값이라 정확히 안 겹칠 수 있어 기준에서 제외한다.)
+        qualifying = [(key, path) for key, path in closed_candidates if key[0] == best_key[0]]
+
+        vector_lookup = compute_score_vector(self.G)
+        diversity_candidates = [
+            (self.utils.path_score_vector(path, vector_lookup), path)
+            for _, path in qualifying
+        ]
+        return self.utils.select_diverse_paths(diversity_candidates, k=3)
 
 
     def _overlap_ratio(self, path: list[int], base_edges: set) -> float:

--- a/src/route_engine/engines/path_utils.py
+++ b/src/route_engine/engines/path_utils.py
@@ -1,7 +1,10 @@
 import math
 import random
+from typing import TypeVar
 
 import networkx as nx
+
+_PathT = TypeVar("_PathT")
 
 _R1_M: float = 30.0   # ROUT-NODE 1차 탐색 반경 (m)
 _R2_M: float = 300.0  # ROUT-NODE 2차 탐색 반경 (m)
@@ -181,6 +184,63 @@ class PathUtils:
         """
         total_m, full_cost = self.metrics(path)
         return self.objective(total_m, total_m, full_cost, target_m) + (tuple(path),)
+
+    # ── 후보 다양화(safety/nature/slope/convenience/accessibility 벡터) ──────────
+    @staticmethod
+    def path_score_vector(path: list[int], vector_lookup: dict) -> dict[str, float]:
+        """
+        scoring_engine.compute_score_vector()가 만든 edge별 벡터를 경로를 따라 성분별로 합산합니다.
+        vector_lookup에 없는 edge(이론상 없어야 하지만 방어적으로)는 0으로 취급합니다.
+
+        path: 노드 id lst: [1, 2, 3, ...]
+        vector_loockup: {(u,v): {"safety": cost, ...}, ...}
+        """
+        totals: dict[str, float] = {}
+        for i in range(len(path) - 1):
+            edge_vector = vector_lookup.get((path[i], path[i + 1])) or {}  # edge 순회
+            for dim, cost in edge_vector.items():
+                totals[dim] = totals.get(dim, 0.0) + cost
+        return totals
+
+    @staticmethod
+    def vector_distance(a: dict[str, float], b: dict[str, float]) -> float:
+        """
+        두 score vector 사이의 유클리드 거리. 각 차원이 이미 같은 단위(미터)라
+        추가 정규화 없이 그대로 비교합니다.
+        """
+        keys = set(a) | set(b)
+        return math.sqrt(sum((a.get(k, 0.0) - b.get(k, 0.0)) ** 2 for k in keys))
+
+    @staticmethod
+    def select_diverse_paths(
+        candidates: list[tuple[dict, _PathT]],
+        k: int = 3,
+    ) -> list[_PathT]:
+        """
+        candidates[0](이미 정해진 대표 후보, 기존 스칼라 키 기준 1등)을 기준으로,
+        나머지 후보 중 벡터 공간에서 서로·이미 뽑힌 후보로부터 최대한 먼 (k-1)개를
+        greedy farthest-point(k-center) 방식으로 추가 선택합니다.
+        candidates가 k개 미만이면 있는 만큼만 반환합니다.
+
+        인자: candidates = [(score_vector, payload), ...] — payload는 노드 ID 리스트뿐
+        아니라 WalkRouteResponse 등 무엇이든 될 수 있다(그대로 통과시키기만 함).
+        반환: 선택된 payload 목록(최대 k개, candidates[0]의 payload가 항상 첫 번째)
+        """
+        if not candidates:
+            return []
+
+        selected = [candidates[0]]
+        remaining = list(candidates[1:])
+
+        while remaining and len(selected) < k:  # 아직 경로 후보 k를 다 못 채웠다면
+            best_idx, best_min_dist = None, -1.0
+            for idx, (vec, _) in enumerate(remaining):
+                min_dist = min(PathUtils.vector_distance(vec, s_vec) for s_vec, _ in selected)  # 벡터 간 유사도 측정
+                if min_dist > best_min_dist:
+                    best_min_dist, best_idx = min_dist, idx  # 선택된 후보와 비교했을 때, 가장 거리가 먼 경로를 후보로 등록
+            selected.append(remaining.pop(best_idx))
+
+        return [path for _, path in selected]
 
     def connect_to(
         self,

--- a/src/route_engine/engines/waypoint.py
+++ b/src/route_engine/engines/waypoint.py
@@ -10,7 +10,9 @@ from src.interfaces.schema.walk_schema import (
 )
 from src.route_engine.engines.oneway_astar import OnewayAstarEngine
 from src.route_engine.engines.oneway_beam import OnewayBeamEngine
+from src.route_engine.engines.path_utils import PathUtils
 from src.route_engine.profiles import ScoringProfile
+from src.route_engine.scoring.scoring_engine import compute_score_vector
 from src.schema.route_schema import OnewayRouteInput, WaypointRouteInput, Weights
 
 logger = logging.getLogger(__name__)
@@ -27,6 +29,14 @@ class WaypointComposerEngine:
     출발지 -> 경유지들 -> 목적지를 구간(leg)별로 나눠, 각 leg에 지정된 모드의
     기존 편도 엔진(OnewayAstarEngine/OnewayBeamEngine)을 순차 호출해 하나의 경로로 이어 붙인다.
     새 탐색 알고리즘을 추가하지 않고 기존 엔진을 조합만 한다.
+
+    oneway_random leg의 OnewayBeamEngine은 다양화한 후보를 최대 3개까지 반환한다.
+    모든 leg가 성공하면, leg별로 같은 인덱스(대표/2번째/3번째)끼리 짝지어 이어붙인
+    "슬롯" 최대 3개를 만들고, 그중 완전히 겹치는 슬롯은 버린 뒤(예: 모든 leg가
+    oneway_shortest라 애초에 대안이 없는 경우) 벡터 다양화(select_diverse_paths)로
+    최종 후보를 정리해 반환한다. leg 개수와 무관하게 항상 최대 3개만 계산하므로
+    leg별 후보를 전부 조합(3^legs)하지는 않는다. 일부 leg가 실패한 경우엔 다양화 없이
+    기존처럼 대표 경로 1개만 이어붙여 반환한다.
     """
 
     def __init__(
@@ -60,8 +70,10 @@ class WaypointComposerEngine:
             (self.inp.end_lat, self.inp.end_lon),              # 목적지
         ]
 
+        total_legs = len(self.inp.leg_modes)
         visited_nodes: set = set()  # 앞선 leg들이 지나간 노드. 다음 leg 탐색에 겹침 페널티로 반영
-        leg_results: List[WalkRouteResponse] = []
+        # leg별로 (그 leg가 반환한 모든 후보 WalkRouteResponse, 그 후보들의 노드열)을 순서대로 쌓는다.
+        leg_candidates: List[tuple] = []
         for i, mode in enumerate(self.inp.leg_modes):
             start_lat, start_lon = stops[i]
             end_lat, end_lon     = stops[i + 1]
@@ -76,7 +88,9 @@ class WaypointComposerEngine:
                 leg_inp, self.G, custom_weights=self.custom_weights, profile=self.profile,
                 visited_nodes=visited_nodes,
             )
-            result = engine.run()[0]  # leg 엔진도 후보 리스트를 반환하므로 1개만 사용
+            leg_responses = engine.run()  # oneway_random이면 최대 3개, oneway_shortest면 1개
+            leg_node_paths = engine.last_path_nodes_by_candidate
+            result = leg_responses[0]  # 대표 후보 — 상태 판정·재시도 로직은 기존처럼 이걸 기준으로 한다
 
             # 다른 엔진들의 base_shortest 대체와 같은 패턴: 실패하면 최단 경로로 재시도
             if result.status != WalkRouteStatus.SUCCESS and mode != "oneway_shortest":
@@ -86,11 +100,14 @@ class WaypointComposerEngine:
                     leg_inp, self.G, custom_weights=self.custom_weights, profile=self.profile,
                     visited_nodes=visited_nodes,
                 )
-                result = engine.run()[0]
+                leg_responses  = engine.run()
+                leg_node_paths = engine.last_path_nodes_by_candidate
+                result = leg_responses[0]
 
-            leg_results.append(result)
+            leg_candidates.append((leg_responses, leg_node_paths))
 
-            logger.info("leg %d/%d 결과: mode=%s status=%s", i + 1, len(self.inp.leg_modes), mode, result.status.value)
+            logger.info("leg %d/%d 결과: mode=%s status=%s 후보수=%d",
+                        i + 1, total_legs, mode, result.status.value, len(leg_responses))
 
             if result.status != WalkRouteStatus.SUCCESS:
                 logger.warning("leg %d에서 최단 경로 대체도 실패해 이후 leg를 생략합니다: status=%s", i + 1, result.status.value)
@@ -98,7 +115,48 @@ class WaypointComposerEngine:
 
             visited_nodes.update(engine.last_path_nodes)  # 실제로 이 leg를 만든 엔진(재시도 포함)의 경로를 누적
 
-        return [self._stitch(leg_results, len(self.inp.leg_modes))]
+        all_legs_succeeded = (
+            len(leg_candidates) == total_legs
+            and all(responses[0].status == WalkRouteStatus.SUCCESS for responses, _ in leg_candidates)
+        )
+
+        # 일부 leg가 실패한 경우엔 다양화 없이 대표 경로 1개만 이어붙여 기존과 동일하게 반환한다.
+        if not all_legs_succeeded:
+            leg_results = [responses[0] for responses, _ in leg_candidates]
+            return [self._stitch(leg_results, total_legs)]
+
+        # 모든 leg가 성공한 경우에만 최대 3개까지 다양화한 전체 경로를 만든다.
+        vector_lookup = compute_score_vector(self.G)
+        seen_node_paths: List[list] = []
+        diversity_candidates: List[tuple] = []  # [(score_vector, WalkRouteResponse), ...]
+        for slot in range(3):
+            node_path = self._concat_leg_nodes([
+                node_paths[min(slot, len(node_paths) - 1)] for _, node_paths in leg_candidates
+            ])
+            if node_path in seen_node_paths:
+                continue  # 이 leg 조합으로는 이미 나온 경로와 완전히 같음(예: 전 leg가 oneway_shortest)
+            seen_node_paths.append(node_path)
+
+            slot_responses = [
+                responses[min(slot, len(responses) - 1)] for responses, _ in leg_candidates
+            ]
+            diversity_candidates.append((
+                PathUtils.path_score_vector(node_path, vector_lookup),
+                self._stitch(slot_responses, total_legs),
+            ))
+
+        return PathUtils.select_diverse_paths(diversity_candidates, k=3)
+
+    @staticmethod
+    def _concat_leg_nodes(leg_node_paths: List[list]) -> list:
+        """
+        leg별 노드열을 하나로 이어붙인다. 인접 leg의 경계 노드는 같은 지점(stop)의
+        동일 노드이므로, 두 번째 leg부터는 첫 노드를 건너뛴다(_stitch의 좌표 처리와 동일한 원리).
+        """
+        combined: list = []
+        for i, nodes in enumerate(leg_node_paths):
+            combined.extend(nodes[1:] if i > 0 else nodes)
+        return combined
 
     def _stitch(self, leg_results: List[WalkRouteResponse], total_legs: int) -> WalkRouteResponse:
         """

--- a/src/route_engine/scoring/scoring_engine.py
+++ b/src/route_engine/scoring/scoring_engine.py
@@ -11,6 +11,10 @@ COMFORT_TAG_PENALTIES = {
     "building_inside": 1.08,
 }
 
+# 후보 경로를 다양화할 때 쓰는 벡터 score의 차원. custom_score의 profile 가중치와는
+# 무관하게, 대표 후보(가중 스칼라 기준 1등)와 다른 두 후보를 고를 때만 쓴다.
+VECTOR_SCORE_DIMENSIONS = ("safety", "nature", "slope", "convenience", "accessibility")
+
 _FEATURE_CACHE_KEY = "_scoring_feature_cache"
 
 
@@ -184,3 +188,32 @@ def compute_custom_score_lookup(graph: nx.Graph, profile: dict) -> dict:
         return _lookup.get((u, v), 1.0)
 
     return {"weight": _weight, "lookup": lookup, "min_ratio": min_ratio}
+
+
+def compute_score_vector(graph: nx.Graph) -> dict[tuple, dict[str, float]]:
+    """
+    완성된 후보 경로들을 다양화하기 위한 edge별 벡터 비용을 계산한다.
+    calculate_custom_score/compute_custom_score_lookup과 달리 profile 가중치를 쓰지 않는다
+    — 대표 후보(후보 1)는 기존 가중 스칼라(custom_score)로 뽑고, 나머지 후보(2·3)는
+    가중치와 무관한 "순수 품질 차이"로 다양화하기 위해 별도로 존재한다.
+
+    각 차원 값은 length * (1 - feature)다. feature(0~1, 1이 가장 좋음)가 1이면 0,
+    0이면 length 전체가 그 차원의 비용으로 잡힌다 — custom_score처럼 경로를 따라
+    그대로 합산할 수 있다(path_utils.path_score_vector 참고).
+
+    반환: {(u, v): {"safety": cost, "nature": cost, ...}, (v, u): {...}, ...}
+    (무방향 그래프이므로 양방향 조회 등록, compute_custom_score_lookup과 동일 패턴)
+    """
+    cache = _get_feature_cache(graph)
+
+    vectors: dict[tuple, dict[str, float]] = {}
+    for i, (u, v) in enumerate(cache["edge_keys"]):
+        length = float(cache["length"][i])
+        edge_vector = {
+            dim: length * (1.0 - float(cache[dim][i]))
+            for dim in VECTOR_SCORE_DIMENSIONS
+        }
+        vectors[(u, v)] = edge_vector
+        vectors[(v, u)] = edge_vector
+
+    return vectors

--- a/src/service/route/route_service.py
+++ b/src/service/route/route_service.py
@@ -152,10 +152,19 @@ class RouteService:
         logger.info("walk route engine selected: mode=%s engine=%s", mode, type(engine).__name__)
 
         results = engine.run()
-        result  = results[0]  # 경로 후보는 1개만 사용
-        logger.info("walk route result: mode=%s status=%s total_km=%s", mode, result.status.value, result.total_km)
+        # circular_random/oneway_random은 이제 최대 3개까지 다양화한 후보를 반환한다(results[0]이 대표 후보).
+        # POI는 성공한 후보 전부에 붙이고, RouteHistory는 아직 대표 후보 1개만 저장한다
+        # — 사용자가 실제로 어떤 후보를 골랐는지는 아직 API로 전달받지 않기 때문이다.
+        # TODO: 사용자가 후보 중 하나를 선택하는 흐름이 생기면, 그때 선택된 후보를 저장하도록 바꾼다.
+        first_result = results[0]
+        logger.info(
+            "walk route result: mode=%s status=%s total_km=%s candidates=%d",
+            mode, first_result.status.value, first_result.total_km, len(results),
+        )
 
-        if result.status == WalkRouteStatus.SUCCESS:
+        for result in results:
+            if result.status != WalkRouteStatus.SUCCESS:
+                continue
             try:
                 result.nearby_pois = [
                     RoutePoiItem.model_validate(poi)
@@ -166,6 +175,7 @@ class RouteService:
             except Exception:
                 logger.exception("route POI lookup failed: mode=%s", mode)
 
+        if first_result.status == WalkRouteStatus.SUCCESS:
             try:
                 user = UserRepository.find_by_provider_and_provider_id(provider, provider_id)
                 if user is not None:
@@ -174,12 +184,12 @@ class RouteService:
                         mode=mode,
                         origin_lat=origin.lat,
                         origin_lon=origin.lon,
-                        coordinates=result.coordinates,
-                        total_km=result.total_km,
+                        coordinates=first_result.coordinates,
+                        total_km=first_result.total_km,
                         destination_lat=destination.lat if destination else None,
                         destination_lon=destination.lon if destination else None,
                     )
-                    result.id = history.id
+                    first_result.id = history.id
             except Exception:
                 logger.exception("walk route history save failed: mode=%s", mode)
 


### PR DESCRIPTION
## ☝️Issue Number
- resolve #358 

## 📝 작업 개요 (이 PR에서 무엇을 했나요?)
- 순환(`circular_random`)·편도 우회(`oneway_random`) 경로 엔진이 단일 경로 대신 **최대 3개까지 다양화된 후보**를 반환하도록 리팩토링했습니다.
  - 안전·자연·평지·편의·접근성을 하나의 스칼라로 뭉치지 않고 별도 벡터(`scoring_engine.compute_score_vector`)로 관리해, 후보 1(기존 방식대로 가중치 기준 대표)과 벡터 공간에서 가장 멀리 떨어진 후보 2개(`path_utils.select_diverse_paths`, greedy farthest-point)를 선택하는 방식입니다.
  - `oneway_beam.py`/`circular_beam.py`가 이 방식으로 최대 3개 후보를 반환하고, 경유지 조합(`waypoint.py`)에도 leg별 후보를 슬롯 단위로 짝지어 전파해 최종적으로 최대 3개의 전체 경로가 나오도록 반영했습니다.
  - `route_service.py`는 성공한 후보 전부에 POI를 붙이고, `RouteHistory`는 대표 후보 1개만 저장하도록 했습니다(사용자가 후보 중 하나를 직접 고르는 흐름은 아직 없어 추후 개선 예정).
- 위 변경에 맞춰 `docs/route_engine/README.md`·`docs/chatbot/agent_harness.md`를 갱신했습니다.